### PR TITLE
fix(deno): add proper getters and setters to abstract classes

### DIFF
--- a/deno_dist/bimultimap/implementation/immutable.ts
+++ b/deno_dist/bimultimap/implementation/immutable.ts
@@ -139,7 +139,9 @@ export class BiMultiMapNonEmpty<
     super();
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   asNormal(): any {
     return this;

--- a/deno_dist/hashed/set/immutable.ts
+++ b/deno_dist/hashed/set/immutable.ts
@@ -10,6 +10,8 @@ export class HashSetEmpty<T = any>
   extends CustomBase.EmptyBase
   implements HashSet<T>
 {
+  readonly addAll: any;
+
   constructor(readonly context: HashSetContext<T>) {
     super();
 
@@ -23,8 +25,6 @@ export class HashSetEmpty<T = any>
   add(value: T): HashSet.NonEmpty<T> {
     return this.context.emptyBlock().add(value);
   }
-
-  addAll: any;
 
   remove(): this {
     return this;
@@ -77,7 +77,7 @@ export abstract class HashSetNonEmptyBase<T>
   extends CustomBase.NonEmptyBase<T>
   implements HashSet.NonEmpty<T>
 {
-  abstract context: HashSetContext<T>;
+  abstract readonly context: HashSetContext<T>;
   abstract readonly size: number;
   abstract stream(): Stream.NonEmpty<T>;
   abstract forEach(

--- a/deno_dist/list/builder/tree/tree-builder.ts
+++ b/deno_dist/list/builder/tree/tree-builder.ts
@@ -15,9 +15,12 @@ import { createFromBlock, createNonLeaf } from '../../list-custom.ts';
 export abstract class TreeBuilderBase<T, C> {
   abstract readonly context: ListContext;
   abstract readonly level: number;
-  abstract left: BlockBuilder<T, C>;
-  abstract right: BlockBuilder<T, C>;
-  abstract middle?: NonLeafBuilder<T, BlockBuilder<T, C>>;
+  abstract get left(): BlockBuilder<T, C>;
+  abstract set left(value: BlockBuilder<T, C>);
+  abstract get right(): BlockBuilder<T, C>;
+  abstract set right(value: BlockBuilder<T, C>);
+  abstract get middle(): NonLeafBuilder<T, BlockBuilder<T, C>> | undefined;
+  abstract set middle(value: NonLeafBuilder<T, BlockBuilder<T, C>> | undefined);
   abstract length: number;
   abstract getChildLength(child: C): number;
 
@@ -64,17 +67,17 @@ export abstract class TreeBuilderBase<T, C> {
     }
 
     if (undefined !== this.middle) {
-      const delta = this.middle.modifyFirstChild((firstChild):
-        | number
-        | undefined => {
-        if (firstChild.nrChildren < this.context.maxBlockSize) {
-          const shiftChild = this.left.dropLast();
-          this.left.prepend(child);
-          firstChild.prepend(shiftChild);
-          return this.getChildLength(shiftChild);
+      const delta = this.middle.modifyFirstChild(
+        (firstChild): number | undefined => {
+          if (firstChild.nrChildren < this.context.maxBlockSize) {
+            const shiftChild = this.left.dropLast();
+            this.left.prepend(child);
+            firstChild.prepend(shiftChild);
+            return this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return;
     } else if (this.right.nrChildren < this.context.maxBlockSize) {
@@ -100,17 +103,17 @@ export abstract class TreeBuilderBase<T, C> {
 
     if (undefined !== this.middle) {
       // try to shift to last middle child
-      const delta = this.middle.modifyLastChild((lastChild):
-        | number
-        | undefined => {
-        if (lastChild.nrChildren < this.context.maxBlockSize) {
-          const shiftChild = this.right.dropFirst();
-          this.right.append(child);
-          lastChild.append(shiftChild);
-          return this.getChildLength(shiftChild);
+      const delta = this.middle.modifyLastChild(
+        (lastChild): number | undefined => {
+          if (lastChild.nrChildren < this.context.maxBlockSize) {
+            const shiftChild = this.right.dropFirst();
+            this.right.append(child);
+            lastChild.append(shiftChild);
+            return this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return;
     } else if (this.left.nrChildren < this.context.maxBlockSize) {
@@ -142,17 +145,17 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // left borrows from middle
-        const delta = this.middle.modifyFirstChild((firstChild):
-          | number
-          | undefined => {
-          if (firstChild.nrChildren > this.context.minBlockSize) {
-            // left borrows from middle's first grandChild
-            const shiftChild = firstChild.dropFirst();
-            this.left.append(shiftChild);
-            return -this.getChildLength(shiftChild);
+        const delta = this.middle.modifyFirstChild(
+          (firstChild): number | undefined => {
+            if (firstChild.nrChildren > this.context.minBlockSize) {
+              // left borrows from middle's first grandChild
+              const shiftChild = firstChild.dropFirst();
+              this.left.append(shiftChild);
+              return -this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         // if borrow was succesful
         if (undefined !== delta) return oldValue;
@@ -181,16 +184,16 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // right borrows from middle
-        const delta = this.middle.modifyLastChild((lastChild):
-          | number
-          | undefined => {
-          if (lastChild.nrChildren > this.context.minBlockSize) {
-            const shiftChild = lastChild.dropLast();
-            this.right.prepend(shiftChild);
-            return -this.getChildLength(shiftChild);
+        const delta = this.middle.modifyLastChild(
+          (lastChild): number | undefined => {
+            if (lastChild.nrChildren > this.context.minBlockSize) {
+              const shiftChild = lastChild.dropLast();
+              this.right.prepend(shiftChild);
+              return -this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         // if borrow was succesful
         if (undefined !== delta) return oldValue;
@@ -227,16 +230,16 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // try shift to middle
-        const delta = this.middle.modifyFirstChild((firstChild):
-          | number
-          | undefined => {
-          if (firstChild.nrChildren < this.context.maxBlockSize) {
-            const shiftChild = this.left.dropLast();
-            firstChild.prepend(shiftChild);
-            return this.getChildLength(shiftChild);
+        const delta = this.middle.modifyFirstChild(
+          (firstChild): number | undefined => {
+            if (firstChild.nrChildren < this.context.maxBlockSize) {
+              const shiftChild = this.left.dropLast();
+              firstChild.prepend(shiftChild);
+              return this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         if (undefined !== delta) return;
       } else if (this.right.nrChildren < this.context.maxBlockSize) {
@@ -261,16 +264,16 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // try to shift child to middle last
-        const delta = this.middle.modifyLastChild((lastChild):
-          | number
-          | undefined => {
-          if (lastChild.nrChildren < this.context.maxBlockSize) {
-            const shiftChild = this.right.dropFirst();
-            lastChild.append(shiftChild);
-            return this.getChildLength(shiftChild);
+        const delta = this.middle.modifyLastChild(
+          (lastChild): number | undefined => {
+            if (lastChild.nrChildren < this.context.maxBlockSize) {
+              const shiftChild = this.right.dropFirst();
+              lastChild.append(shiftChild);
+              return this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         if (undefined !== delta) return;
       } else if (this.left.nrChildren < this.context.maxBlockSize) {
@@ -374,16 +377,16 @@ export abstract class TreeBuilderBase<T, C> {
     if (this.left.nrChildren >= this.context.minBlockSize) return first;
 
     if (undefined !== this.middle) {
-      const delta = this.middle.modifyFirstChild((firstChild):
-        | number
-        | undefined => {
-        if (firstChild.nrChildren > this.context.minBlockSize) {
-          const shiftChild = firstChild.dropFirst();
-          this.left.append(shiftChild);
-          return -this.getChildLength(shiftChild);
+      const delta = this.middle.modifyFirstChild(
+        (firstChild): number | undefined => {
+          if (firstChild.nrChildren > this.context.minBlockSize) {
+            const shiftChild = firstChild.dropFirst();
+            this.left.append(shiftChild);
+            return -this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return first;
 
@@ -409,16 +412,16 @@ export abstract class TreeBuilderBase<T, C> {
     if (this.right.nrChildren >= this.context.minBlockSize) return last;
 
     if (undefined !== this.middle) {
-      const delta = this.middle.modifyLastChild((lastChild):
-        | number
-        | undefined => {
-        if (lastChild.nrChildren > this.context.minBlockSize) {
-          const shiftChild = lastChild.dropLast();
-          this.right.prepend(shiftChild);
-          return -this.getChildLength(shiftChild);
+      const delta = this.middle.modifyLastChild(
+        (lastChild): number | undefined => {
+          if (lastChild.nrChildren > this.context.minBlockSize) {
+            const shiftChild = lastChild.dropLast();
+            this.right.prepend(shiftChild);
+            return -this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return last;
 

--- a/deno_dist/list/implementation/leaf/non-empty.ts
+++ b/deno_dist/list/implementation/leaf/non-empty.ts
@@ -29,7 +29,7 @@ export abstract class ListNonEmptyBase<T>
   extends CustomBase.NonEmptyBase<T>
   implements List.NonEmpty<T>
 {
-  abstract context: ListContext;
+  abstract readonly context: ListContext;
   abstract readonly length: number;
   abstract stream(reversed?: boolean): Stream.NonEmpty<T>;
   abstract streamRange(range: IndexRange, reversed?: boolean): Stream<T>;

--- a/deno_dist/multiset/implementation/base.ts
+++ b/deno_dist/multiset/implementation/base.ts
@@ -130,7 +130,9 @@ export class MultiSetNonEmpty<
     super();
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   asNormal(): any {
     return this;

--- a/deno_dist/ordered/map/implementation/non-empty.ts
+++ b/deno_dist/ordered/map/implementation/non-empty.ts
@@ -58,7 +58,9 @@ export class OrderedMapNonEmpty<
     return this;
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   stream(): Stream.NonEmpty<[K, V]> {
     return this.streamKeys().map((k): [K, V] => [

--- a/deno_dist/ordered/set/implementation/non-empty.ts
+++ b/deno_dist/ordered/set/implementation/non-empty.ts
@@ -28,7 +28,9 @@ export class OrderedSetNonEmpty<
     return this;
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   copy(order = this.order, sourceSet = this.sourceSet): TpG['nonEmpty'] {
     return this.context.createNonEmpty<T>(order, sourceSet as any);

--- a/deno_dist/sorted/base.ts
+++ b/deno_dist/sorted/base.ts
@@ -37,7 +37,7 @@ export abstract class SortedNonEmptyBase<
   abstract getAtIndex<O>(index: number, otherwise?: OptLazy<O>): E | O;
 
   // internal
-  abstract entries: readonly E[];
+  abstract readonly entries: readonly E[];
 
   abstract takeInternal(amount: number): TS;
   abstract dropInternal(amount: number): TS;
@@ -663,7 +663,8 @@ export abstract class SortedBuilder<E> {
   };
   abstract _entries?: E[];
   abstract _children?: SortedBuilder<E>[];
-  abstract children: SortedBuilder<E>[];
+  abstract get children(): SortedBuilder<E>[];
+  abstract set children(value: SortedBuilder<E>[]);
   abstract size: number;
   abstract prepareMutate(): void;
   abstract createNew(

--- a/deno_dist/table/implementation/base.ts
+++ b/deno_dist/table/implementation/base.ts
@@ -170,7 +170,9 @@ export class TableNonEmpty<
     super();
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   asNormal(): any {
     return this;

--- a/packages/bimultimap/src/implementation/immutable.ts
+++ b/packages/bimultimap/src/implementation/immutable.ts
@@ -139,7 +139,9 @@ export class BiMultiMapNonEmpty<
     super();
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   asNormal(): any {
     return this;

--- a/packages/hashed/src/set/immutable.ts
+++ b/packages/hashed/src/set/immutable.ts
@@ -10,6 +10,8 @@ export class HashSetEmpty<T = any>
   extends CustomBase.EmptyBase
   implements HashSet<T>
 {
+  readonly addAll: any;
+
   constructor(readonly context: HashSetContext<T>) {
     super();
 
@@ -23,8 +25,6 @@ export class HashSetEmpty<T = any>
   add(value: T): HashSet.NonEmpty<T> {
     return this.context.emptyBlock().add(value);
   }
-
-  addAll: any;
 
   remove(): this {
     return this;
@@ -77,7 +77,7 @@ export abstract class HashSetNonEmptyBase<T>
   extends CustomBase.NonEmptyBase<T>
   implements HashSet.NonEmpty<T>
 {
-  abstract context: HashSetContext<T>;
+  abstract readonly context: HashSetContext<T>;
   abstract readonly size: number;
   abstract stream(): Stream.NonEmpty<T>;
   abstract forEach(

--- a/packages/list/src/builder/tree/tree-builder.ts
+++ b/packages/list/src/builder/tree/tree-builder.ts
@@ -15,9 +15,12 @@ import { createFromBlock, createNonLeaf } from '../../list-custom';
 export abstract class TreeBuilderBase<T, C> {
   abstract readonly context: ListContext;
   abstract readonly level: number;
-  abstract left: BlockBuilder<T, C>;
-  abstract right: BlockBuilder<T, C>;
-  abstract middle?: NonLeafBuilder<T, BlockBuilder<T, C>>;
+  abstract get left(): BlockBuilder<T, C>;
+  abstract set left(value: BlockBuilder<T, C>);
+  abstract get right(): BlockBuilder<T, C>;
+  abstract set right(value: BlockBuilder<T, C>);
+  abstract get middle(): NonLeafBuilder<T, BlockBuilder<T, C>> | undefined;
+  abstract set middle(value: NonLeafBuilder<T, BlockBuilder<T, C>> | undefined);
   abstract length: number;
   abstract getChildLength(child: C): number;
 
@@ -64,17 +67,17 @@ export abstract class TreeBuilderBase<T, C> {
     }
 
     if (undefined !== this.middle) {
-      const delta = this.middle.modifyFirstChild((firstChild):
-        | number
-        | undefined => {
-        if (firstChild.nrChildren < this.context.maxBlockSize) {
-          const shiftChild = this.left.dropLast();
-          this.left.prepend(child);
-          firstChild.prepend(shiftChild);
-          return this.getChildLength(shiftChild);
+      const delta = this.middle.modifyFirstChild(
+        (firstChild): number | undefined => {
+          if (firstChild.nrChildren < this.context.maxBlockSize) {
+            const shiftChild = this.left.dropLast();
+            this.left.prepend(child);
+            firstChild.prepend(shiftChild);
+            return this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return;
     } else if (this.right.nrChildren < this.context.maxBlockSize) {
@@ -100,17 +103,17 @@ export abstract class TreeBuilderBase<T, C> {
 
     if (undefined !== this.middle) {
       // try to shift to last middle child
-      const delta = this.middle.modifyLastChild((lastChild):
-        | number
-        | undefined => {
-        if (lastChild.nrChildren < this.context.maxBlockSize) {
-          const shiftChild = this.right.dropFirst();
-          this.right.append(child);
-          lastChild.append(shiftChild);
-          return this.getChildLength(shiftChild);
+      const delta = this.middle.modifyLastChild(
+        (lastChild): number | undefined => {
+          if (lastChild.nrChildren < this.context.maxBlockSize) {
+            const shiftChild = this.right.dropFirst();
+            this.right.append(child);
+            lastChild.append(shiftChild);
+            return this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return;
     } else if (this.left.nrChildren < this.context.maxBlockSize) {
@@ -142,17 +145,17 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // left borrows from middle
-        const delta = this.middle.modifyFirstChild((firstChild):
-          | number
-          | undefined => {
-          if (firstChild.nrChildren > this.context.minBlockSize) {
-            // left borrows from middle's first grandChild
-            const shiftChild = firstChild.dropFirst();
-            this.left.append(shiftChild);
-            return -this.getChildLength(shiftChild);
+        const delta = this.middle.modifyFirstChild(
+          (firstChild): number | undefined => {
+            if (firstChild.nrChildren > this.context.minBlockSize) {
+              // left borrows from middle's first grandChild
+              const shiftChild = firstChild.dropFirst();
+              this.left.append(shiftChild);
+              return -this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         // if borrow was succesful
         if (undefined !== delta) return oldValue;
@@ -181,16 +184,16 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // right borrows from middle
-        const delta = this.middle.modifyLastChild((lastChild):
-          | number
-          | undefined => {
-          if (lastChild.nrChildren > this.context.minBlockSize) {
-            const shiftChild = lastChild.dropLast();
-            this.right.prepend(shiftChild);
-            return -this.getChildLength(shiftChild);
+        const delta = this.middle.modifyLastChild(
+          (lastChild): number | undefined => {
+            if (lastChild.nrChildren > this.context.minBlockSize) {
+              const shiftChild = lastChild.dropLast();
+              this.right.prepend(shiftChild);
+              return -this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         // if borrow was succesful
         if (undefined !== delta) return oldValue;
@@ -227,16 +230,16 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // try shift to middle
-        const delta = this.middle.modifyFirstChild((firstChild):
-          | number
-          | undefined => {
-          if (firstChild.nrChildren < this.context.maxBlockSize) {
-            const shiftChild = this.left.dropLast();
-            firstChild.prepend(shiftChild);
-            return this.getChildLength(shiftChild);
+        const delta = this.middle.modifyFirstChild(
+          (firstChild): number | undefined => {
+            if (firstChild.nrChildren < this.context.maxBlockSize) {
+              const shiftChild = this.left.dropLast();
+              firstChild.prepend(shiftChild);
+              return this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         if (undefined !== delta) return;
       } else if (this.right.nrChildren < this.context.maxBlockSize) {
@@ -261,16 +264,16 @@ export abstract class TreeBuilderBase<T, C> {
 
       if (undefined !== this.middle) {
         // try to shift child to middle last
-        const delta = this.middle.modifyLastChild((lastChild):
-          | number
-          | undefined => {
-          if (lastChild.nrChildren < this.context.maxBlockSize) {
-            const shiftChild = this.right.dropFirst();
-            lastChild.append(shiftChild);
-            return this.getChildLength(shiftChild);
+        const delta = this.middle.modifyLastChild(
+          (lastChild): number | undefined => {
+            if (lastChild.nrChildren < this.context.maxBlockSize) {
+              const shiftChild = this.right.dropFirst();
+              lastChild.append(shiftChild);
+              return this.getChildLength(shiftChild);
+            }
+            return;
           }
-          return;
-        });
+        );
 
         if (undefined !== delta) return;
       } else if (this.left.nrChildren < this.context.maxBlockSize) {
@@ -374,16 +377,16 @@ export abstract class TreeBuilderBase<T, C> {
     if (this.left.nrChildren >= this.context.minBlockSize) return first;
 
     if (undefined !== this.middle) {
-      const delta = this.middle.modifyFirstChild((firstChild):
-        | number
-        | undefined => {
-        if (firstChild.nrChildren > this.context.minBlockSize) {
-          const shiftChild = firstChild.dropFirst();
-          this.left.append(shiftChild);
-          return -this.getChildLength(shiftChild);
+      const delta = this.middle.modifyFirstChild(
+        (firstChild): number | undefined => {
+          if (firstChild.nrChildren > this.context.minBlockSize) {
+            const shiftChild = firstChild.dropFirst();
+            this.left.append(shiftChild);
+            return -this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return first;
 
@@ -409,16 +412,16 @@ export abstract class TreeBuilderBase<T, C> {
     if (this.right.nrChildren >= this.context.minBlockSize) return last;
 
     if (undefined !== this.middle) {
-      const delta = this.middle.modifyLastChild((lastChild):
-        | number
-        | undefined => {
-        if (lastChild.nrChildren > this.context.minBlockSize) {
-          const shiftChild = lastChild.dropLast();
-          this.right.prepend(shiftChild);
-          return -this.getChildLength(shiftChild);
+      const delta = this.middle.modifyLastChild(
+        (lastChild): number | undefined => {
+          if (lastChild.nrChildren > this.context.minBlockSize) {
+            const shiftChild = lastChild.dropLast();
+            this.right.prepend(shiftChild);
+            return -this.getChildLength(shiftChild);
+          }
+          return;
         }
-        return;
-      });
+      );
 
       if (undefined !== delta) return last;
 

--- a/packages/list/src/implementation/leaf/non-empty.ts
+++ b/packages/list/src/implementation/leaf/non-empty.ts
@@ -29,7 +29,7 @@ export abstract class ListNonEmptyBase<T>
   extends CustomBase.NonEmptyBase<T>
   implements List.NonEmpty<T>
 {
-  abstract context: ListContext;
+  abstract readonly context: ListContext;
   abstract readonly length: number;
   abstract stream(reversed?: boolean): Stream.NonEmpty<T>;
   abstract streamRange(range: IndexRange, reversed?: boolean): Stream<T>;

--- a/packages/multiset/src/implementation/base.ts
+++ b/packages/multiset/src/implementation/base.ts
@@ -130,7 +130,9 @@ export class MultiSetNonEmpty<
     super();
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   asNormal(): any {
     return this;

--- a/packages/ordered/src/map/implementation/non-empty.ts
+++ b/packages/ordered/src/map/implementation/non-empty.ts
@@ -58,7 +58,9 @@ export class OrderedMapNonEmpty<
     return this;
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   stream(): Stream.NonEmpty<[K, V]> {
     return this.streamKeys().map((k): [K, V] => [

--- a/packages/ordered/src/set/implementation/non-empty.ts
+++ b/packages/ordered/src/set/implementation/non-empty.ts
@@ -28,7 +28,9 @@ export class OrderedSetNonEmpty<
     return this;
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   copy(order = this.order, sourceSet = this.sourceSet): TpG['nonEmpty'] {
     return this.context.createNonEmpty<T>(order, sourceSet as any);

--- a/packages/sorted/src/base.ts
+++ b/packages/sorted/src/base.ts
@@ -37,7 +37,7 @@ export abstract class SortedNonEmptyBase<
   abstract getAtIndex<O>(index: number, otherwise?: OptLazy<O>): E | O;
 
   // internal
-  abstract entries: readonly E[];
+  abstract readonly entries: readonly E[];
 
   abstract takeInternal(amount: number): TS;
   abstract dropInternal(amount: number): TS;
@@ -663,7 +663,8 @@ export abstract class SortedBuilder<E> {
   };
   abstract _entries?: E[];
   abstract _children?: SortedBuilder<E>[];
-  abstract children: SortedBuilder<E>[];
+  abstract get children(): SortedBuilder<E>[];
+  abstract set children(value: SortedBuilder<E>[]);
   abstract size: number;
   abstract prepareMutate(): void;
   abstract createNew(

--- a/packages/table/src/implementation/base.ts
+++ b/packages/table/src/implementation/base.ts
@@ -170,7 +170,9 @@ export class TableNonEmpty<
     super();
   }
 
-  assumeNonEmpty: any;
+  assumeNonEmpty(): any {
+    return this;
+  }
 
   asNormal(): any {
     return this;


### PR DESCRIPTION
 and implement defined abstract methods

Apparently Deno is more strict about abstract classes defining properties that are implemented with
getters and setters. This caused runtime errors, and has now been fixed. Also, methods that are
implemented in an abstract class and then only defined in subclasses do not work, they need an
implementation or will cause runtime errors.

fixes #18
