### PR TITLE
feat(bimap): change update method names and reverse parameters for up…

### DIFF
--- a/deno_dist/bimap/custom/implementation/immutable.ts
+++ b/deno_dist/bimap/custom/implementation/immutable.ts
@@ -89,11 +89,11 @@ export class BiMapEmpty<K = any, V = any>
     return this;
   }
 
-  updateKeyAt(): this {
+  updateKeyAtValue(): this {
     return this;
   }
 
-  updateValueAt(): this {
+  updateValueAtKey(): this {
     return this;
   }
 
@@ -345,22 +345,22 @@ export class BiMapNonEmptyImpl<K, V>
     return builder.build();
   }
 
-  updateValueAt(key: K, update: Update<V>): BiMap.NonEmpty<K, V> {
+  updateValueAtKey(key: K, valueUpdate: Update<V>): BiMap.NonEmpty<K, V> {
     const token = Symbol();
     const currentValue = this.getValue(key, token);
     if (token === currentValue) return this;
 
-    const newValue = Update(currentValue, update);
+    const newValue = Update(currentValue, valueUpdate);
     if (Object.is(newValue, currentValue)) return this;
     return this.set(key, newValue);
   }
 
-  updateKeyAt(value: V, update: Update<K>): BiMap.NonEmpty<K, V> {
+  updateKeyAtValue(keyUpdate: Update<K>, value: V): BiMap.NonEmpty<K, V> {
     const token = Symbol();
     const result = this.getKey(value, token);
     if (token === result) return this;
 
-    const newKey = Update(result, update);
+    const newKey = Update(result, keyUpdate);
     if (Object.is(newKey, result)) return this;
     return this.set(newKey, value);
   }

--- a/deno_dist/bimap/main/interface.ts
+++ b/deno_dist/bimap/main/interface.ts
@@ -262,37 +262,43 @@ export interface BiMap<K, V> extends FastIterable<readonly [K, V]> {
    */
   removeValues<UV = V>(value: StreamSource<RelatedTo<V, UV>>): BiMap<K, V>;
   /**
-   * Returns the collection where the value associated with given `key` is updated with the given `update` value or update function.
+   * Returns the collection where the value associated with given `key` is updated with the given `valueUpdate` value or update function.
    * @param key - the key of the entry to update
-   * @param update - a new value or function taking the current value and returning a new value
+   * @param valueUpdate - a new value or function taking the current value and returning a new value
    * @example
    * ```ts
    * const m = BiMap.of([1, 1], [2, 2])
-   * m.updateValueAt(3, 3).toArray()
+   * m.updateValueAtKey(3, 3).toArray()
    * // => [[1, 1], [2, 2]]
-   * m.updateValueAt(2, 10).toArray()
+   * m.updateValueAtKey(2, 10).toArray()
    * // => [[1, 1], [2, 10]]
-   * m.updateValueAt(1, v => v + 1)
+   * m.updateValueAtKey(1, v => v + 1)
    * // => [[1, 2]]
    * ```
    */
-  updateValueAt<UK = K>(key: RelatedTo<K, UK>, update: Update<V>): BiMap<K, V>;
+  updateValueAtKey<UK = K>(
+    key: RelatedTo<K, UK>,
+    valueUpdate: Update<V>
+  ): BiMap<K, V>;
   /**
-   * Returns the collection where the key associated with given `value` is updated with the given `update` value or update function.
+   * Returns the collection where the key associated with given `value` is updated with the given `keyUpdate` value or update function.
+   * @param keyUpdate - a new value or function taking the current key and returning a new key
    * @param value - the value of the entry to update
-   * @param update - a new value or function taking the current key and returning a new key
    * @example
    * ```ts
    * const m = BiMap.of([1, 1], [2, 2])
-   * m.updateKeyAt(3, 3).toArray()
+   * m.updateKeyAtValue(3, 3).toArray()
    * // => [[1, 1], [2, 2]]
-   * m.updateKeyAt(2, 10).toArray()
+   * m.updateKeyAtValue(10, 2).toArray()
    * // => [[1, 1], [10, 2]]
-   * m.updateKeyAt(1, v => v + 1)
+   * m.updateKeyAtValue((v) => v + 1, 1)
    * // => [[2, 1]]
    * ```
    */
-  updateKeyAt<UV = V>(value: RelatedTo<V, UV>, update: Update<K>): BiMap<K, V>;
+  updateKeyAtValue<UV = V>(
+    keyUpdate: Update<K>,
+    value: RelatedTo<V, UV>
+  ): BiMap<K, V>;
   /**
    * Returns a `Stream` containing all entries of this collection as tuples of key and value.
    * @example
@@ -462,7 +468,7 @@ export namespace BiMap {
     /**
      * Returns the collection where the value associated with given `key` is updated with the given `update` value or update function.
      * @param key - the key of the entry to update
-     * @param update - a new value or function taking the current value and returning a new value
+     * @param valueUpdate - a new value or function taking the current value and returning a new value
      * @example
      * ```ts
      * const m = BiMap.of([1, 1], [2, 2])
@@ -474,28 +480,28 @@ export namespace BiMap {
      * // => [[1, 2]]
      * ```
      */
-    updateValueAt<UK = K>(
+    updateValueAtKey<UK = K>(
       key: RelatedTo<K, UK>,
-      update: Update<V>
+      valueUpdate: Update<V>
     ): BiMap.NonEmpty<K, V>;
     /**
      * Returns the collection where the key associated with given `value` is updated with the given `update` value or update function.
+     * @param keyUpdate - a new value or function taking the current key and returning a new key
      * @param value - the value of the entry to update
-     * @param update - a new value or function taking the current key and returning a new key
      * @example
      * ```ts
      * const m = BiMap.of([1, 1], [2, 2])
-     * m.updateKeyAt(3, 3).toArray()
+     * m.updateKeyAtValue(3, 3).toArray()
      * // => [[1, 1], [2, 2]]
-     * m.updateKeyAt(2, 10).toArray()
+     * m.updateKeyAtValue(10, 2).toArray()
      * // => [[1, 1], [10, 2]]
-     * m.updateKeyAt(1, v => v + 1)
+     * m.updateKeyAtValue((v) => v + 1, 1)
      * // => [[2, 1]]
      * ```
      */
-    updateKeyAt<UV = V>(
-      value: RelatedTo<V, UV>,
-      update: Update<K>
+    updateKeyAtValue<UV = V>(
+      keyUpdate: Update<K>,
+      value: RelatedTo<V, UV>
     ): BiMap.NonEmpty<K, V>;
     /**
      * Returns a non-empty `Stream` containing all entries of this collection as tuples of key and value.

--- a/packages/bimap/src/custom/implementation/immutable.ts
+++ b/packages/bimap/src/custom/implementation/immutable.ts
@@ -89,11 +89,11 @@ export class BiMapEmpty<K = any, V = any>
     return this;
   }
 
-  updateKeyAt(): this {
+  updateKeyAtValue(): this {
     return this;
   }
 
-  updateValueAt(): this {
+  updateValueAtKey(): this {
     return this;
   }
 
@@ -345,22 +345,22 @@ export class BiMapNonEmptyImpl<K, V>
     return builder.build();
   }
 
-  updateValueAt(key: K, update: Update<V>): BiMap.NonEmpty<K, V> {
+  updateValueAtKey(key: K, valueUpdate: Update<V>): BiMap.NonEmpty<K, V> {
     const token = Symbol();
     const currentValue = this.getValue(key, token);
     if (token === currentValue) return this;
 
-    const newValue = Update(currentValue, update);
+    const newValue = Update(currentValue, valueUpdate);
     if (Object.is(newValue, currentValue)) return this;
     return this.set(key, newValue);
   }
 
-  updateKeyAt(value: V, update: Update<K>): BiMap.NonEmpty<K, V> {
+  updateKeyAtValue(keyUpdate: Update<K>, value: V): BiMap.NonEmpty<K, V> {
     const token = Symbol();
     const result = this.getKey(value, token);
     if (token === result) return this;
 
-    const newKey = Update(result, update);
+    const newKey = Update(result, keyUpdate);
     if (Object.is(newKey, result)) return this;
     return this.set(newKey, value);
   }

--- a/packages/bimap/src/main/interface.ts
+++ b/packages/bimap/src/main/interface.ts
@@ -262,37 +262,43 @@ export interface BiMap<K, V> extends FastIterable<readonly [K, V]> {
    */
   removeValues<UV = V>(value: StreamSource<RelatedTo<V, UV>>): BiMap<K, V>;
   /**
-   * Returns the collection where the value associated with given `key` is updated with the given `update` value or update function.
+   * Returns the collection where the value associated with given `key` is updated with the given `valueUpdate` value or update function.
    * @param key - the key of the entry to update
-   * @param update - a new value or function taking the current value and returning a new value
+   * @param valueUpdate - a new value or function taking the current value and returning a new value
    * @example
    * ```ts
    * const m = BiMap.of([1, 1], [2, 2])
-   * m.updateValueAt(3, 3).toArray()
+   * m.updateValueAtKey(3, 3).toArray()
    * // => [[1, 1], [2, 2]]
-   * m.updateValueAt(2, 10).toArray()
+   * m.updateValueAtKey(2, 10).toArray()
    * // => [[1, 1], [2, 10]]
-   * m.updateValueAt(1, v => v + 1)
+   * m.updateValueAtKey(1, v => v + 1)
    * // => [[1, 2]]
    * ```
    */
-  updateValueAt<UK = K>(key: RelatedTo<K, UK>, update: Update<V>): BiMap<K, V>;
+  updateValueAtKey<UK = K>(
+    key: RelatedTo<K, UK>,
+    valueUpdate: Update<V>
+  ): BiMap<K, V>;
   /**
-   * Returns the collection where the key associated with given `value` is updated with the given `update` value or update function.
+   * Returns the collection where the key associated with given `value` is updated with the given `keyUpdate` value or update function.
+   * @param keyUpdate - a new value or function taking the current key and returning a new key
    * @param value - the value of the entry to update
-   * @param update - a new value or function taking the current key and returning a new key
    * @example
    * ```ts
    * const m = BiMap.of([1, 1], [2, 2])
-   * m.updateKeyAt(3, 3).toArray()
+   * m.updateKeyAtValue(3, 3).toArray()
    * // => [[1, 1], [2, 2]]
-   * m.updateKeyAt(2, 10).toArray()
+   * m.updateKeyAtValue(10, 2).toArray()
    * // => [[1, 1], [10, 2]]
-   * m.updateKeyAt(1, v => v + 1)
+   * m.updateKeyAtValue((v) => v + 1, 1)
    * // => [[2, 1]]
    * ```
    */
-  updateKeyAt<UV = V>(value: RelatedTo<V, UV>, update: Update<K>): BiMap<K, V>;
+  updateKeyAtValue<UV = V>(
+    keyUpdate: Update<K>,
+    value: RelatedTo<V, UV>
+  ): BiMap<K, V>;
   /**
    * Returns a `Stream` containing all entries of this collection as tuples of key and value.
    * @example
@@ -462,7 +468,7 @@ export namespace BiMap {
     /**
      * Returns the collection where the value associated with given `key` is updated with the given `update` value or update function.
      * @param key - the key of the entry to update
-     * @param update - a new value or function taking the current value and returning a new value
+     * @param valueUpdate - a new value or function taking the current value and returning a new value
      * @example
      * ```ts
      * const m = BiMap.of([1, 1], [2, 2])
@@ -474,28 +480,28 @@ export namespace BiMap {
      * // => [[1, 2]]
      * ```
      */
-    updateValueAt<UK = K>(
+    updateValueAtKey<UK = K>(
       key: RelatedTo<K, UK>,
-      update: Update<V>
+      valueUpdate: Update<V>
     ): BiMap.NonEmpty<K, V>;
     /**
      * Returns the collection where the key associated with given `value` is updated with the given `update` value or update function.
+     * @param keyUpdate - a new value or function taking the current key and returning a new key
      * @param value - the value of the entry to update
-     * @param update - a new value or function taking the current key and returning a new key
      * @example
      * ```ts
      * const m = BiMap.of([1, 1], [2, 2])
-     * m.updateKeyAt(3, 3).toArray()
+     * m.updateKeyAtValue(3, 3).toArray()
      * // => [[1, 1], [2, 2]]
-     * m.updateKeyAt(2, 10).toArray()
+     * m.updateKeyAtValue(10, 2).toArray()
      * // => [[1, 1], [10, 2]]
-     * m.updateKeyAt(1, v => v + 1)
+     * m.updateKeyAtValue((v) => v + 1, 1)
      * // => [[2, 1]]
      * ```
      */
-    updateKeyAt<UV = V>(
-      value: RelatedTo<V, UV>,
-      update: Update<K>
+    updateKeyAtValue<UV = V>(
+      keyUpdate: Update<K>,
+      value: RelatedTo<V, UV>
     ): BiMap.NonEmpty<K, V>;
     /**
      * Returns a non-empty `Stream` containing all entries of this collection as tuples of key and value.

--- a/packages/bimap/test-d/bimap.test-d.ts
+++ b/packages/bimap/test-d/bimap.test-d.ts
@@ -109,13 +109,13 @@ expectType<ArrayNonEmpty<readonly [number, string]>>(bNonEmpty.toArray());
 expectType<BiMap.Builder<number, string>>(bEmpty.toBuilder());
 expectType<BiMap.Builder<number, string>>(bNonEmpty.toBuilder());
 
-// .updateKeyAt(..)
-expectType<B_Empty>(bEmpty.updateKeyAt('b', 2));
-expectType<B_NonEmpty>(bNonEmpty.updateKeyAt('b', 2));
+// .updateKeyAtValue(..)
+expectType<B_Empty>(bEmpty.updateKeyAtValue(2, 'b'));
+expectType<B_NonEmpty>(bNonEmpty.updateKeyAtValue(2, 'b'));
 
-// .updateValueAt(..)
-expectType<B_Empty>(bEmpty.updateValueAt(2, 'b'));
-expectType<B_NonEmpty>(bNonEmpty.updateValueAt(2, 'b'));
+// .updateValueAtKey(..)
+expectType<B_Empty>(bEmpty.updateValueAtKey(2, 'b'));
+expectType<B_NonEmpty>(bNonEmpty.updateValueAtKey(2, 'b'));
 
 // From Builder
 expectType<B_Empty>(bEmpty.toBuilder().build());

--- a/packages/bimap/test/bimap.test.ts
+++ b/packages/bimap/test/bimap.test.ts
@@ -419,30 +419,30 @@ describe('BiMap methods', () => {
     expect(map3_1.toString()).toBe(`BiMap(1 <-> a, 2 <-> b, 3 <-> c)`);
   });
 
-  it('updateKeyAt', () => {
-    expect(mapEmpty.updateKeyAt('b', 10)).toBe(mapEmpty);
-    expect(mapEmpty.updateKeyAt('b', (v) => v + v)).toBe(mapEmpty);
+  it('updateKeyAtValue', () => {
+    expect(mapEmpty.updateKeyAtValue(10, 'b')).toBe(mapEmpty);
+    expect(mapEmpty.updateKeyAtValue((v) => v + v, 'b')).toBe(mapEmpty);
 
-    expect(map3_1.updateKeyAt('b', 10).getKey('b')).toBe(10);
-    expect(map3_1.updateKeyAt('b', (v) => v + v).getKey('b')).toBe(4);
-    expect(map3_1.updateKeyAt('z', 10)).toBe(map3_1);
+    expect(map3_1.updateKeyAtValue(10, 'b').getKey('b')).toBe(10);
+    expect(map3_1.updateKeyAtValue((v) => v + v, 'b').getKey('b')).toBe(4);
+    expect(map3_1.updateKeyAtValue(10, 'z')).toBe(map3_1);
 
-    expect(map6_1.updateKeyAt('b', 10).getKey('b')).toBe(10);
-    expect(map6_1.updateKeyAt('b', (v) => v + v).getKey('b')).toBe(4);
-    expect(map6_1.updateKeyAt('z', 10)).toBe(map6_1);
+    expect(map6_1.updateKeyAtValue(10, 'b').getKey('b')).toBe(10);
+    expect(map6_1.updateKeyAtValue((v) => v + v, 'b').getKey('b')).toBe(4);
+    expect(map6_1.updateKeyAtValue(10, 'z')).toBe(map6_1);
   });
 
-  it('updateValueAt', () => {
-    expect(mapEmpty.updateValueAt(2, 'z')).toBe(mapEmpty);
-    expect(mapEmpty.updateValueAt(2, (v) => v + v)).toBe(mapEmpty);
+  it('updateValueAtKey', () => {
+    expect(mapEmpty.updateValueAtKey(2, 'z')).toBe(mapEmpty);
+    expect(mapEmpty.updateValueAtKey(2, (v) => v + v)).toBe(mapEmpty);
 
-    expect(map3_1.updateValueAt(2, 'z').getValue(2)).toBe('z');
-    expect(map3_1.updateValueAt(2, (v) => v + v).getValue(2)).toBe('bb');
-    expect(map3_1.updateValueAt(10, 'z')).toBe(map3_1);
+    expect(map3_1.updateValueAtKey(2, 'z').getValue(2)).toBe('z');
+    expect(map3_1.updateValueAtKey(2, (v) => v + v).getValue(2)).toBe('bb');
+    expect(map3_1.updateValueAtKey(10, 'z')).toBe(map3_1);
 
-    expect(map6_1.updateValueAt(2, 'z').getValue(2)).toBe('z');
-    expect(map6_1.updateValueAt(2, (v) => v + v).getValue(2)).toBe('bb');
-    expect(map6_1.updateValueAt(10, 'z')).toBe(map6_1);
+    expect(map6_1.updateValueAtKey(2, 'z').getValue(2)).toBe('z');
+    expect(map6_1.updateValueAtKey(2, (v) => v + v).getValue(2)).toBe('bb');
+    expect(map6_1.updateValueAtKey(10, 'z')).toBe(map6_1);
   });
 });
 


### PR DESCRIPTION
…dateKeyAt method

the update methods were confusing, longer names should clarify this. also changed the order for updateKeyAtValue so that the key is always first

BREAKING CHANGE: changed updateKeyAt to updateKeyAtValue, and updateValueAt to updateValueAtKey, and reversed parameter order for updateKeyAtValue to always have key first

Fixes #101 
