### PR TITLE
feat(deep): add array item traversal matching, update and fix docs

### DIFF
--- a/docs/docs/deep/match.mdx
+++ b/docs/docs/deep/match.mdx
@@ -159,7 +159,7 @@ match(
   },
   {
     b: {
-      d: { e: (value, parent, root) => value === parent.c + root.a },
+      c: (value, parent, root) => value === parent.d.e - root.a,
     },
   }
 ); // => true
@@ -172,7 +172,7 @@ match(
   },
   {
     b: {
-      d: { e: (value, parent, root) => parent.c + root.a },
+      c: (value, parent, root) => parent.d.e - root.a,
     },
   }
 ); // => true

--- a/docs/docs/deep/match.mdx
+++ b/docs/docs/deep/match.mdx
@@ -103,11 +103,12 @@ match(
 
 ### Arrays and Tuples
 
-To match arrays and tuples, there are two options:
+To match arrays and tuples, the following options are available:
 
-- match each element by `Object.is`
+- provide an array of matchers that will match each element at the corresponding index
 - provide an object with matchers for specific indices
-- compound matches wrapped in an object
+- traversal matches to apply to each element in the array
+- compound matches for the entire array wrapped in an object
 
 ```ts
 const arr: number[] = [1, 2, 3];
@@ -120,14 +121,20 @@ const tup = [1, true, 'a'] as [number, boolean, string];
 match(tup, [1, false, 'a']); // -> false, element 1 does not match
 match(tup, { 0: 1, 2: 'a' }); // -> true, elements at index 0 and 2 match
 
+// traversal matches
+match(arr, { someItem: 2 }); // -> true, 2 matches an element is in the array
+match(arr, { everyItem: (v) => v < 3 }); // -> false, last item does not match
+
 // compound matches
 match(
   [
     { x: 1, y: 2 },
     { x: 3, y: 0 },
   ],
-  { some: [{ x: (v) => v > 5 }, { y: (v) => v < 2 }] }
-); // -> true, matches the first item
+  { some: [{ someItem: { x: 2 } }, { someItem: { y: 0 } }] }
+); // -> true, matches the second condition, because there is an item in the array with y = 0
+
+// explained fully, this last match looks for some element in the array where x = 2 or y = 0
 ```
 
 ### Function matchers
@@ -143,6 +150,7 @@ The matcher function receives three arguments:
 
 ```ts
 match(1, (v) => v > 0); // => true
+match(1, (v) => v * 2 - 1); // => true
 
 match(
   {

--- a/packages/deep/test-d/match.test-d.ts
+++ b/packages/deep/test-d/match.test-d.ts
@@ -117,6 +117,10 @@ expectType<boolean>(match(v3, { 1024: 1, 1025: undefined }));
 expectType<boolean>(match(v3, { some: [{ 1: 1 }] }));
 expectType<boolean>(match(v3, { every: [{ 1: 1 }] }));
 expectType<boolean>(match(v3, { some: [{ 1: 1 }, (v) => v.length > 3] }));
+expectType<boolean>(match(v3, { someItem: 2 }));
+expectType<boolean>(match(v3, { everyItem: 2 }));
+expectType<boolean>(match(v3, { noneItem: 2 }));
+expectType<boolean>(match(v3, { singleItem: 2 }));
 
 expectType<boolean>(match(v3, () => v3));
 expectType<boolean>(match(v3, () => []));
@@ -127,6 +131,10 @@ expectType<boolean>(match(v3, () => ({ some: [{ 1: 1 }] })));
 expectType<boolean>(
   match(v3, () => ({ some: [{ 1: 1 }, (v) => v.length > 3] }))
 );
+expectType<boolean>(match(v3, { someItem: () => 2 }));
+expectType<boolean>(match(v3, { everyItem: () => 2 }));
+expectType<boolean>(match(v3, { noneItem: () => 2 }));
+expectType<boolean>(match(v3, { singleItem: () => 2 }));
 
 expectError(match(v3, ['a']));
 expectError(match(v3, { a: 'a' }));
@@ -172,3 +180,15 @@ const v5 = { a: 1 } as { a: number } | [number, number];
 
 // expectType<boolean>(match(v5, { a: 5 }));
 expectType<boolean>(match(v5, [5, 4]));
+
+const v6 = [{ x: 1, y: 2 }];
+
+expectType<boolean>(match(v6, v6));
+expectType<boolean>(match(v6, [{ x: 1 }]));
+expectType<boolean>(match(v6, { someItem: { x: 1 } }));
+expectType<boolean>(match(v6, { someItem: () => ({ x: 1 }) }));
+
+expectType<boolean>(match(v6, () => v6));
+expectType<boolean>(match(v6, () => [{ x: 1 }]));
+expectType<boolean>(match(v6, () => ({ someItem: { x: 1 } })));
+expectType<boolean>(match(v6, () => ({ someItem: () => ({ x: 1 }) })));


### PR DESCRIPTION
Fixes #109 

Adds the option to match arrays with partial matchers per index.
Adds the option to provide traversal matches to match all array elements: `someItem`, `everyItem`, `noneItem`, and `singleItem`.
Fixes the documentation providing an incorrect example.
