### PR TITLE
feat(stream): adds a `live` async stream constructor that can be used…

### DIFF
--- a/deno_dist/stream/async-custom/async-fast-iterator-base.ts
+++ b/deno_dist/stream/async-custom/async-fast-iterator-base.ts
@@ -293,7 +293,7 @@ export class FromIterator<T> extends AsyncFastIteratorBase<T> {
 
     if (result.done) {
       await closeIters(this);
-      return AsyncOptLazy.toPromise(otherwise!);
+      return AsyncOptLazy.toMaybePromise(otherwise!);
     }
     return result.value;
   }
@@ -322,6 +322,60 @@ export class FromPromise<T> extends AsyncFastIteratorBase<T> {
     }
 
     return this.iterator!.fastNext(otherwise!);
+  }
+}
+
+export class AsyncLiveIterator<T> extends AsyncFastIteratorBase<T> {
+  constructor(readonly maxSize: number) {
+    super();
+  }
+
+  readonly queue: T[] = [];
+
+  waitPromise: Promise<void> | undefined;
+
+  wakeUp: (() => void) | undefined;
+
+  submit = (value: T): void => {
+    if (this.halted) {
+      return;
+    }
+
+    this.queue.unshift(value);
+
+    if (this.queue.length > this.maxSize) {
+      this.queue.length = this.maxSize;
+    }
+    this.wakeUp?.();
+  };
+
+  halted = false;
+
+  close = (): void => {
+    this.halted = true;
+    this.wakeUp?.();
+  };
+
+  async fastNext<O>(otherwise?: AsyncOptLazy<O> | undefined): Promise<T | O> {
+    const { queue } = this;
+
+    if (queue.length > 0) {
+      const item = queue.pop()!;
+
+      return item;
+    }
+
+    if (this.halted) {
+      return AsyncOptLazy.toMaybePromise(otherwise!);
+    }
+
+    const waitPromise = new Promise<void>((res) => {
+      this.wakeUp = res;
+    });
+    await waitPromise;
+    this.wakeUp = undefined;
+
+    return this.fastNext(otherwise);
   }
 }
 

--- a/deno_dist/stream/async-custom/constructors.ts
+++ b/deno_dist/stream/async-custom/constructors.ts
@@ -19,6 +19,17 @@ export interface AsyncStreamConstructors {
     createSource: (resource: R) => MaybePromise<AsyncStreamSource<T>>,
     close: (resource: R) => MaybePromise<void>
   ): AsyncStream<T>;
+  /**
+   * Returns a tuple of a controller and a stream, where the controller can be used to
+   * submit values and close the stream, and the stream will emit the submitted values, with
+   * a buffer of maximum length thte given `maxSize`. Each stream client will start buffering
+   * from the moment that it is created.
+   * @param maxSize - the maximum buffer size
+   * @typeparam T - the element type
+   */
+  live<T>(
+    maxSize?: number
+  ): [{ submit(value: T): void; close: () => void }, AsyncStream<T>];
   /** Returns an AsyncStream with the result of applying given `zipFun` to each successive value resulting from the given `sources`.
    * @param sources - the input async stream sources
    * @param zipFun - a potentially asynchronous function taking one element from each given Stream, and returning a result value

--- a/packages/stream/src/async-custom/async-fast-iterator-base.ts
+++ b/packages/stream/src/async-custom/async-fast-iterator-base.ts
@@ -293,7 +293,7 @@ export class FromIterator<T> extends AsyncFastIteratorBase<T> {
 
     if (result.done) {
       await closeIters(this);
-      return AsyncOptLazy.toPromise(otherwise!);
+      return AsyncOptLazy.toMaybePromise(otherwise!);
     }
     return result.value;
   }
@@ -322,6 +322,60 @@ export class FromPromise<T> extends AsyncFastIteratorBase<T> {
     }
 
     return this.iterator!.fastNext(otherwise!);
+  }
+}
+
+export class AsyncLiveIterator<T> extends AsyncFastIteratorBase<T> {
+  constructor(readonly maxSize: number) {
+    super();
+  }
+
+  readonly queue: T[] = [];
+
+  waitPromise: Promise<void> | undefined;
+
+  wakeUp: (() => void) | undefined;
+
+  submit = (value: T): void => {
+    if (this.halted) {
+      return;
+    }
+
+    this.queue.unshift(value);
+
+    if (this.queue.length > this.maxSize) {
+      this.queue.length = this.maxSize;
+    }
+    this.wakeUp?.();
+  };
+
+  halted = false;
+
+  close = (): void => {
+    this.halted = true;
+    this.wakeUp?.();
+  };
+
+  async fastNext<O>(otherwise?: AsyncOptLazy<O> | undefined): Promise<T | O> {
+    const { queue } = this;
+
+    if (queue.length > 0) {
+      const item = queue.pop()!;
+
+      return item;
+    }
+
+    if (this.halted) {
+      return AsyncOptLazy.toMaybePromise(otherwise!);
+    }
+
+    const waitPromise = new Promise<void>((res) => {
+      this.wakeUp = res;
+    });
+    await waitPromise;
+    this.wakeUp = undefined;
+
+    return this.fastNext(otherwise);
   }
 }
 

--- a/packages/stream/src/async-custom/async-stream-custom.ts
+++ b/packages/stream/src/async-custom/async-stream-custom.ts
@@ -55,6 +55,7 @@ import {
   AsyncTakeIterator,
   AsyncTakeWhileIterator,
   AsyncWindowIterator,
+  AsyncLiveIterator,
 } from '@rimbu/stream/async-custom';
 import { Stream } from '@rimbu/stream';
 import type { StreamSource } from '@rimbu/stream';
@@ -1718,6 +1719,56 @@ export const AsyncStreamConstructorsImpl: AsyncStreamConstructors =
     },
     fromResource(open, createSource, close): any {
       return new FromResource(open, createSource, close);
+    },
+    live<T>(
+      maxSize = 100
+    ): [{ submit(value: T): void; close(): void }, AsyncStream<T>] {
+      const listenerIterators = new Set<AsyncLiveIterator<T>>();
+
+      let closed = false;
+
+      function subscribe(iter: AsyncLiveIterator<T>): void {
+        if (closed) {
+          iter.close();
+          return;
+        }
+
+        listenerIterators.add(iter);
+      }
+
+      function submit(value: T): void {
+        if (closed) {
+          return;
+        }
+
+        for (const listenerIterator of listenerIterators) {
+          listenerIterator.submit(value);
+        }
+      }
+
+      function close(): void {
+        if (closed) {
+          return;
+        }
+
+        closed = true;
+        for (const listener of listenerIterators) {
+          listener.close();
+        }
+        listenerIterators.clear();
+      }
+
+      const stream = new AsyncFromStream(() => {
+        if (closed) {
+          return emptyAsyncFastIterator;
+        }
+
+        const iter = new AsyncLiveIterator<T>(maxSize);
+        subscribe(iter);
+        return iter;
+      });
+
+      return [{ submit, close }, stream];
     },
     zipWith(...sources): any {
       return (zipFun: any): any => {

--- a/packages/stream/src/async-custom/constructors.ts
+++ b/packages/stream/src/async-custom/constructors.ts
@@ -19,6 +19,17 @@ export interface AsyncStreamConstructors {
     createSource: (resource: R) => MaybePromise<AsyncStreamSource<T>>,
     close: (resource: R) => MaybePromise<void>
   ): AsyncStream<T>;
+  /**
+   * Returns a tuple of a controller and a stream, where the controller can be used to
+   * submit values and close the stream, and the stream will emit the submitted values, with
+   * a buffer of maximum length thte given `maxSize`. Each stream client will start buffering
+   * from the moment that it is created.
+   * @param maxSize - the maximum buffer size
+   * @typeparam T - the element type
+   */
+  live<T>(
+    maxSize?: number
+  ): [{ submit(value: T): void; close: () => void }, AsyncStream<T>];
   /** Returns an AsyncStream with the result of applying given `zipFun` to each successive value resulting from the given `sources`.
    * @param sources - the input async stream sources
    * @param zipFun - a potentially asynchronous function taking one element from each given Stream, and returning a result value

--- a/packages/stream/test/async-stream.test.ts
+++ b/packages/stream/test/async-stream.test.ts
@@ -395,6 +395,27 @@ describe('AsyncStream methods', () => {
       expect(close).toBeCalledTimes(1);
     }
   });
+  it('live', async () => {
+    {
+      const [control, stream] = AsyncStream.live<number>();
+
+      setTimeout(() => {
+        control.submit(1);
+        control.submit(2);
+        control.submit(3);
+        control.close();
+      }, 100);
+
+      expect(await stream.toArray()).toEqual([1, 2, 3]);
+    }
+
+    {
+      const [control, stream] = AsyncStream.live<number>();
+      control.close();
+
+      expect(await stream.toArray()).toEqual([]);
+    }
+  });
   it('indexed', async () => {
     expect(AsyncStream.empty().indexed()).toBe(AsyncStream.empty());
     expect(await AsyncStream.of(1).indexed().toArray()).toEqual([[0, 1]]);


### PR DESCRIPTION
… to broadcast values

Fixes #124 
