### PR TITLE
Connect the documentation of the "proximity" package

### DIFF
--- a/config/tsconfig.extractor.base.json
+++ b/config/tsconfig.extractor.base.json
@@ -71,6 +71,7 @@
         "../packages/ordered/dist/types/set-custom"
       ],
       "@rimbu/proximity": ["../packages/proximity/dist/types/main"],
+      "@rimbu/proximity/common": ["../packages/proximity/dist/types/common"],
       "@rimbu/proximity/map": ["../packages/proximity/dist/types/map"],
       "@rimbu/proximity/map-custom": [
         "../packages/proximity/dist/types/map-custom"

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -22,10 +22,11 @@ To read how to get started with Rimbu, see the [Getting Started page](/docs/gett
 | [`@rimbu/deep`](/api/rimbu/deep)                         | Provides utilities to patch and match plain JavaScript objects.                         |
 | [`@rimbu/graph`](/api/rimbu/graph)                       | Provides many types of Graph implementations.                                           |
 | [`@rimbu/hashed`](/api/rimbu/hashed)                     | Pprovides implementations of the `HashSet` and `HashMap`.                               |
-| [`@rimbu/list](/api/rimbu/list)                          | Provides the `List` implementation.                                                     |
-| [`@rimbu/multimap](/api/rimbu/multimap)                  | Provides implementations for various MultiMaps.                                         |
-| [`@rimbu/multiset](/api/rimbu/multiset)                  | Provides implementations for various MultiSets.                                         |
-| [`@rimbu/ordered](/api/rimbu/ordered)                    | Provides various `OrderedMap` and `OrderedSet` implementations.                         |
-| [`@rimbu/sorted](/api/rimbu/sorted)                      | Provides implementations for sorted maps and sets.                                      |
-| [`@rimbu/stream](/api/rimbu/stream)                      | Provides the `Stream` and `AsyncStream` implementations and many related utilities.     |
-| [`@rimbu/table](/api/rimbu/table)                        | Provides implementations for tables (2-dimensional maps).                               |
+| [`@rimbu/list`](/api/rimbu/list)                         | Provides the `List` implementation.                                                     |
+| [`@rimbu/multimap`](/api/rimbu/multimap)                 | Provides implementations for various MultiMaps.                                         |
+| [`@rimbu/multiset`](/api/rimbu/multiset)                 | Provides implementations for various MultiSets.                                         |
+| [`@rimbu/ordered`](/api/rimbu/ordered)                   | Provides various `OrderedMap` and `OrderedSet` implementations.                         |
+| [`@rimbu/proximity`](/api/rimbu/proximity)               | Provides `ProximityMap`, for retrieving a value from the _closest_ key                  |
+| [`@rimbu/sorted`](/api/rimbu/sorted)                     | Provides implementations for sorted maps and sets.                                      |
+| [`@rimbu/stream`](/api/rimbu/stream)                     | Provides the `Stream` and `AsyncStream` implementations and many related utilities.     |
+| [`@rimbu/table`](/api/rimbu/table)                       | Provides implementations for tables (2-dimensional maps).                               |

--- a/docs/docs/advanced/advanced-concepts.mdx
+++ b/docs/docs/advanced/advanced-concepts.mdx
@@ -101,6 +101,6 @@ The Rimbu Builder API's are generally not as expressive as the immutable ones, s
 
 ### No iterators
 
-Rimbu Builders are not iterable. Iterating over a mutable object is inherantly unsafe, since in the iteration it is possible to mutate the object, causing all kinds of nasty side-effects.
+Rimbu Builders are not iterable. Iterating over a mutable object is inherently unsafe, since in the iteration it is possible to mutate the object, causing all kinds of nasty side-effects.
 
 The only way to perform logic on all the elements in a builder, is to use the `.forEach(...)` methods. When performing a `forEach` on a builder, performing any mutation on the builder will throw a runtime error. This is to protect against unpredictable behaviors.

--- a/docs/docs/collections/map.mdx
+++ b/docs/docs/collections/map.mdx
@@ -32,6 +32,10 @@ The `SortedMap` uses a `Comp` instance that can compare two elements and return 
 
 The `OrderedMap` maintains an extra `List` or the inserted keys in insertion order. At the cost of extra memory usage for the List, the `OrderedMap` will return entries in the insertion order when iterating over its values.
 
+## ProximityMap
+
+`ProximityMap` is a map whose `get()` method is based not on _equality_, but on _proximity_: it performs an interruptible linear scan of all the keys, returning the value associated with the key _closest_ to the given input key, according to an arbitrary _distance function_.
+
 ## Exports
 
 The `@rimbu/core` package exports the following _abstract_ Map TypeScript types:
@@ -43,11 +47,12 @@ The `@rimbu/core` package exports the following _abstract_ Map TypeScript types:
 
 The `@rimbu/core` package exports the following _concrete_ Map TypeScript types:
 
-| Name                                                          | Description                                                                                |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [`HashMap<K, V>`](/api/rimbu/hashed/map/HashMap/namespace)    | a map with entries of key type K and value type V, where keys are hashed with a `Hasher`   |
-| [`SortedMap<K, V>`](/api/rimbu/sorted/SortedMap/namespace)    | a map with entries of key type K and value type V, where keys are sorted with a `Comp`     |
-| [`OrderedMap<K, V>`](/api/rimbu/ordered/OrderedMap/namespace) | a map with entries of key type K and value type V, where key insertion order is maintained |
+| Name                                                                | Description                                                                                      |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [`HashMap<K, V>`](/api/rimbu/hashed/map/HashMap/namespace)          | a map with entries of key type K and value type V, where keys are hashed with a `Hasher`         |
+| [`SortedMap<K, V>`](/api/rimbu/sorted/SortedMap/namespace)          | a map with entries of key type K and value type V, where keys are sorted with a `Comp`           |
+| [`OrderedMap<K, V>`](/api/rimbu/ordered/OrderedMap/namespace)       | a map with entries of key type K and value type V, where key insertion order is maintained       |
+| [`ProximityMap<K, V>`](/api/rimbu/proximity/ProximityMap/namespace) | a map with entries of key type K and value type V, where value retrieval is based on _proximity_ |
 
 ## Inheritance
 

--- a/docs/docs/collections/map.ts
+++ b/docs/docs/collections/map.ts
@@ -10,4 +10,5 @@ Streamable <|.. VariantMap;
 VariantMap <|-- RMap;
 RMap <|-- HashMap;
 RMap <|-- SortedMap;
+RMap <|-- ProximityMap;
 `;

--- a/packages/proximity/config/api-extractor.common.json
+++ b/packages/proximity/config/api-extractor.common.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "extends": "<projectFolder>/../../config/api-extractor.json",
+  "mainEntryPointFilePath": "<projectFolder>dist/types/common/index.d.ts",
+  "bundledPackages": [],
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "<projectFolder>/../../doc-gen/input/<unscopedPackageName>!map.api.json"
+  },
+  "compiler": {
+    "tsconfigFilePath": "<projectFolder>/tsconfig.extractor.json"
+  }
+}

--- a/packages/proximity/src/common/distanceFunction.ts
+++ b/packages/proximity/src/common/distanceFunction.ts
@@ -3,21 +3,22 @@
  *
  * * 0 - meaning the two values are equal
  *
- * * `POSITIVE_INFINITY` - the two values are so distant that can never match
+ * * `Number.POSITIVE_INFINITY` - the two values are so distant that can never match
  */
 export type Distance = number;
 
 /**
  * Measures the distance between two values.
  *
- * @returns The distance between its arguments, in a [0; +Inf] range
+ * @returns The distance between its arguments, in a [`0`; `Number.POSITIVE_INFINITY`] range
  */
 export type DistanceFunction<T> = (one: T, another: T) => Distance;
 
 export namespace DistanceFunction {
   /**
-   * Sensible default distance function, based on ===
-   * @returns 0 if the two values satisfy ===, Number.POSITIVE_INFINITY otherwise
+   * Sensible default distance function, based on `===`
+   *
+   * @returns `0` if the two values satisfy `===`, `Number.POSITIVE_INFINITY` otherwise
    */
   export const defaultFunction: DistanceFunction<unknown> = (
     one: unknown,

--- a/packages/proximity/src/common/keyMatching.ts
+++ b/packages/proximity/src/common/keyMatching.ts
@@ -24,10 +24,10 @@ export type NearestKeyMatch<K, V> = Readonly<{
  *
  * Performs a full linear scan unless a distance equal to 0 is encountered, in which
  * case the function returns immediately; otherwise, the algorithm selects the
- * smallest non-infinite distance: if multiple keys happen to have such distance,
+ * smallest *non-infinite* distance: if multiple keys happen to have such distance,
  * the selection order is not guaranteed.
  *
- * @param distanceFunction Returns the distance between 2 keys
+ * @param distanceFunction Returns the distance between two keys
  * @param key The key used as a reference to find the closest key
  * @param entries The [key, value] entries
  * @returns A `NearestKeyMatch` object if a closest key -

--- a/packages/proximity/src/main/index.ts
+++ b/packages/proximity/src/main/index.ts
@@ -7,7 +7,7 @@
  * <br/>
  * This is a convenience package that exports everything from the following sub-packages:<br/>
  * - [`@rimbu/proximity/common`](./common)<br/>
- * - [`@rimbu/proximity/map`](./map)<br/>
+ * - [`@rimbu/proximity/map`](/api/rimbu/proximity/map)<br/>
  */
 
 export * from '../common';

--- a/packages/proximity/src/map/index.ts
+++ b/packages/proximity/src/map/index.ts
@@ -21,8 +21,8 @@ import { ProximityMapContext } from '../map-custom';
  * The `get()` method is designed to perform an interruptible linear scan of all the keys,
  * returning the value associated with the key closest to the input key.
  *
- * See the [Map documentation](https://rimbu.org/docs/collections/map) and the
- * [ProximityMap API documentation](https://rimbu.org/api/rimbu/proximity/map/ProximityMap/interface)
+ * See the [Map documentation](/collections/map) and the
+ * [ProximityMap API documentation](/api/rimbu/proximity/map/ProximityMap/interface)
  * @typeparam K - the key type
  * @typeparam V - the value type
  * @example
@@ -45,8 +45,8 @@ export namespace ProximityMap {
    * however, optimized distance functions can greatly improve efficiency by
    * preventing a full scan.
    *
-   * See the [Map documentation](https://rimbu.org/docs/collections/map) and the
-   * [ProximityMap API documentation](https://rimbu.org/api/rimbu/proximity/map/ProximityMap/interface)
+   * See the [Map documentation](/docs/collections/map) and the
+   * [ProximityMap API documentation](/api/rimbu/proximity/map/ProximityMap/interface)
    * @typeparam K - the key type
    * @typeparam V - the value type
    * @example
@@ -94,8 +94,8 @@ export namespace ProximityMap {
 
   /**
    * A mutable `ProximityMap` builder used to efficiently create new immutable instances.
-   * See the [Map documentation](https://rimbu.org/docs/collections/map) and the
-   * [ProximityMap.Builder API documentation](https://rimbu.org/api/rimbu/proximity/ProximityMap/Builder/interface)
+   * See the [Map documentation](/docs/collections/map) and the
+   * [ProximityMap.Builder API documentation](/api/rimbu/proximity/ProximityMap/Builder/interface)
    * @typeparam K - the key type
    * @typeparam V - the value type
    */


### PR DESCRIPTION
The purpose of this pull request is to plug the documentation of the `proximity` package into Rimbu's documentation system.

It mostly works, as there remain just the following open issues that could require your intervention:

[ ] On localhost, Docusaurus shows the `proximity` package in the API sidebar - whereas the online website does not 

[ ] In the API sidebar, there should be a way to make the `common` subpackage appear

[ ] On the [welcome page](http://localhost:3000/api/rimbu/proximity) of the `proximity` package, the 2 links before the "Interfaces" header are broken in the browser even though they are correct in the source code