### PR TITLE
List sorting

### DIFF
--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rimbu/list",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "An efficient immutable ordered sequence of elements akin to a Vector",
   "keywords": [
     "list",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rimbu/list",
-  "version": "0.13.0",
+  "version": "0.12.2",
   "description": "An efficient immutable ordered sequence of elements akin to a Vector",
   "keywords": [
     "list",

--- a/packages/list/src/custom/implementation/empty.ts
+++ b/packages/list/src/custom/implementation/empty.ts
@@ -46,6 +46,10 @@ export class Empty<T = any> extends EmptyBase implements List<T> {
     return this;
   }
 
+  sort(): this {
+    return this;
+  }
+
   splice(options: { insert?: StreamSource<T> }): any {
     if (undefined === options.insert) return this;
 

--- a/packages/list/src/custom/implementation/leaf/non-empty.ts
+++ b/packages/list/src/custom/implementation/leaf/non-empty.ts
@@ -3,6 +3,7 @@ import { NonEmptyBase } from '@rimbu/collection-types/set-custom';
 import {
   ArrayNonEmpty,
   CollectFun,
+  Comp,
   IndexRange,
   OptLazy,
   ToJSON,
@@ -91,6 +92,12 @@ export abstract class ListNonEmptyBase<T>
 
     if (!reversed) return values;
     return values.reversed();
+  }
+
+  sort(comp?: Comp<T>): List.NonEmpty<T> {
+    const sortedArray = this.toArray().sort(comp?.compare);
+
+    return this.context.from(sortedArray);
   }
 
   splice({

--- a/packages/list/src/main/interface.ts
+++ b/packages/list/src/main/interface.ts
@@ -221,6 +221,10 @@ export interface List<T> extends FastIterable<T> {
   /**
    * Returns the values sorted according to the given, optional Comp.
    *
+   * **Performance warning**: this method is not designed for frequent calls;
+   * should you need to keep in order a collection with potentially duplicate values,
+   * please consider `SortedMultiSet` instead.
+   *
    * @param comp The comparison logic to use; if missing, the default JavaScript sorting algorithm is applied
    * @returns A sorted copy of the list
    */
@@ -785,6 +789,10 @@ export namespace List {
 
     /**
      * Returns the values sorted according to the given, optional Comp.
+     *
+     * **Performance warning**: this method is not designed for frequent calls;
+     * should you need to keep in order a collection with potentially duplicate values,
+     * please consider `SortedMultiSet` instead.
      *
      * @param comp The comparison logic to use; if missing, the default JavaScript sorting algorithm is applied
      * @returns A sorted copy of the list

--- a/packages/list/src/main/interface.ts
+++ b/packages/list/src/main/interface.ts
@@ -1,6 +1,7 @@
 import type {
   ArrayNonEmpty,
   CollectFun,
+  Comp,
   IndexRange,
   OptLazy,
   ToJSON,
@@ -216,6 +217,15 @@ export interface List<T> extends FastIterable<T> {
    * @note O(logB(N)) for block size B
    */
   slice(range: IndexRange, reversed?: boolean): List<T>;
+
+  /**
+   * Returns the values sorted according to the given, optional Comp.
+   *
+   * @param comp The comparison logic to use; if missing, the default JavaScript sorting algorithm is applied
+   * @returns A sorted copy of the list
+   */
+  sort(comp?: Comp<T>): List<T>;
+
   /**
    * Returns the List, where at the given `index` the `remove` amount of values are replaced by the values
    * from the optionally given `insert` `StreamSource`.
@@ -772,6 +782,15 @@ export namespace List {
       range?: IndexRange,
       reversed?: boolean
     ): List<T2>;
+
+    /**
+     * Returns the values sorted according to the given, optional Comp.
+     *
+     * @param comp The comparison logic to use; if missing, the default JavaScript sorting algorithm is applied
+     * @returns A sorted copy of the list
+     */
+    sort(comp?: Comp<T>): List.NonEmpty<T>;
+
     /**
      * Returns the List, where at the given `index` the `remove` amount of values are replaced by the values
      * from the optionally given `insert` `StreamSource`.

--- a/packages/list/test/list.test.ts
+++ b/packages/list/test/list.test.ts
@@ -1,4 +1,4 @@
-import type { CollectFun } from '@rimbu/common';
+import { Comp, type CollectFun } from '@rimbu/common';
 import { Stream } from '@rimbu/stream';
 import { List as ListSrc } from '@rimbu/list';
 
@@ -270,6 +270,58 @@ describe('List methods', () => {
     expect(list6_2.slice({ start: 2, amount: 3 }, true).toArray()).toEqual([
       5, 4, 3,
     ]);
+  });
+
+  it('sort', () => {
+    //Empty list
+    expect(List.empty().sort()).toBe(List.empty());
+
+    //Empty list, using arbitrary Comp
+    expect(List.empty().sort(Comp.numberComp())).toBe(List.empty());
+
+    //Strings
+    expect(List.from(['C', 'E', 'B', 'A', 'D']).sort()).toEqual(
+      List.from(['A', 'B', 'C', 'D', 'E'])
+    );
+
+    //Strings, with duplicates
+    expect(List.from(['A', 'C', 'B', 'A', 'B', 'C', 'A']).sort()).toEqual(
+      List.from(['A', 'A', 'A', 'B', 'B', 'C', 'C'])
+    );
+
+    //Default number sorting
+    expect(List.from([90, 4, 8, 100, 7, 1, 9]).sort()).toEqual(
+      List.from([1, 100, 4, 7, 8, 9, 90])
+    );
+
+    //Comp-based number sorting
+    expect(List.from([90, 4, 8, 100, 7, 1, 9]).sort(Comp.numberComp())).toEqual(
+      List.from([1, 4, 7, 8, 9, 90, 100])
+    );
+
+    //Duplicate numbers
+    expect(
+      List.from([90, 4, 7, 90, 8, 100, 7, 1, 9, 7]).sort(Comp.numberComp())
+    ).toEqual(List.from([1, 4, 7, 7, 7, 8, 9, 90, 90, 100]));
+
+    //Dates, with duplicates
+    expect(
+      List.from([
+        new Date(2000, 10, 10),
+        new Date(2000, 3, 3),
+        new Date(1986, 3, 29),
+        new Date(2000, 3, 3),
+        new Date(1998, 5, 13),
+      ]).sort(Comp.dateComp())
+    ).toEqual(
+      List.from([
+        new Date(1986, 3, 29),
+        new Date(1998, 5, 13),
+        new Date(2000, 3, 3),
+        new Date(2000, 3, 3),
+        new Date(2000, 10, 10),
+      ])
+    );
   });
 
   it('splice', () => {


### PR DESCRIPTION
The purpose of this pull request consists in adding a `sort()` method to the `List` interfaces - with return value tailored to the empty/non-empty state of each target list.