### PR TITLE
Fix SortedSetBuilder.add() for class instances

### DIFF
--- a/packages/sorted/src/set-custom/implementation/builder.ts
+++ b/packages/sorted/src/set-custom/implementation/builder.ts
@@ -124,12 +124,7 @@ export class SortedSetBuilder<T> extends SortedBuilder<T> {
     const entryIndex = this.context.findIndex(value, this.entries);
 
     if (entryIndex >= 0) {
-      if (Object.is(this.entries[entryIndex], value)) return false;
-
-      this.source = undefined;
-
-      this.entries[entryIndex] = value;
-      return true;
+      return false;
     }
 
     const childIndex = SortedIndex.next(entryIndex);


### PR DESCRIPTION
This (tiny) pull request stems from an aspect of `SortedSetBuilder.add()` that I find fairly confusing and inconsistent: when adding class instances using a custom comparator:

* if I add once again *the very same instance*, `add()` returns `false` - *as expected*

* if I add another instance that is *structurally equal* - and, consequently, makes `Comp.compare()` return `0` - I found  out that `add()` returns `true`!

I feel this is inconsistent for the following reasons:

* there can be algorithms where I need to know if a newly-created object **structurally** belongs to the accumulated set - especially because in this case we do not have `Eq` available. As a matter of fact, such a scenario  (+ some painful debugging 😓) led me to this discovery

* furthermore, in logical terms, the builder will finally create a `SortedSet` having *no structural duplicates* - which can be clearly proven by restoring the original code in `SortedSetBuilder` and commenting out the assertions at lines **269** and **270**

I suspect that the current code in `SortedSetBuilder` stems from the specular code in `SortedMapBuilder` - but the latter seems correct because `Comp` actually works on the *keys* - so `Object.is()` seems the most reasonable way to deal with the entry *values*; however, in the case of `SortedSetBuilder`, I would say the present change proposal is more effective in terms of expected behaviour.