### PR TITLE
fix: insert inserts 1 more item than expected for rational index

### DIFF
--- a/packages/list/src/custom/implementation/leaf/leaf-tree.mts
+++ b/packages/list/src/custom/implementation/leaf/leaf-tree.mts
@@ -106,7 +106,8 @@ export class LeafTree<T>
     );
   }
 
-  take(amount: number): List<T> | any {
+  take(amountInput: number): List<T> | any {
+    const amount = Math.floor(amountInput);
     if (amount === 0) return this.context.empty();
     if (amount >= this.length || -amount > this.length) return this;
     if (amount < 0) return this.drop(this.length + amount);

--- a/packages/list/test/list.test.mts
+++ b/packages/list/test/list.test.mts
@@ -1107,3 +1107,43 @@ describe('List.Builder', () => {
     expect(l3.buildMap(addOne).toArray()).toEqual([2, 3, 4, 5, 6, 7]);
   });
 });
+
+describe('List inserts', () => {
+  /* produced array after 28 iterations is correct:
+  [
+    1,  3,  5,  7,  9, 11, 13, 15, 17,
+   19, 21, 23, 25, 27, 28, 26, 24, 22,
+   20, 18, 16, 14, 12, 10,  8,  6,  4,
+    2,  0
+ ]
+ produced array after 29 iterations contains two 28 and one 29
+ [
+    1,  3,  5,  7,  9, 11, 13, 15, 17,
+   19, 21, 23, 25, 27, 28, 29, 28, 26,
+   24, 22, 20, 18, 16, 14, 12, 10,  8,
+    6,  4,  2,  0
+ ]
+ */
+  it('inserts in the middle', () => {
+    const maxInserts = 1000; // test a lot of cases, because this happend only "sometimes", first occurence is 29
+    let list = List.empty<number>();
+    for (let i = 0; i < maxInserts; i++) {
+      const index = list.length / 2; // caution this can produce .5 values
+      list = list.insert(index, [i]);
+
+      expect(list.length).toBe(i + 1);
+    }
+  });
+});
+
+/*
+Reason for insert bug is take with an non intereg rational number as arugment, test for isolation
+*/
+describe('List take', () => {
+  it('take as much as wanted and no more', () => {
+    const list = List.from<number>(Stream.range({ amount: 5 }));
+
+    const mutatedList = list.take(3.5); //.concat([i + 1], list.drop(i));
+    expect(mutatedList.length).toBe(3);
+  });
+});


### PR DESCRIPTION
Fixes #issue_nr - no issue, just PR

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint and formatted your code locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?


Hi @vitoke , 
first thanks for this project I really like the ideas and I did some performance testing: WOW

I tried appending to lists, prepending list and inserting in the middle of a list. To be honest, I might not have been the best Idea to use length/2 to find the index to insert to, but I did not expect the list to get 2 extra items instead of just the one I wanted to insert.

In my opinion it should not happen. Reason was insert uses splice, and splice uses take and take had a problem when rational numbers are used as index. One more time it makes me sad, typescript has no concept of integer.

The first commit is to create tests to show the error. Second commit is the fix, to use Math.floor on input index in take.

Test placement might not be ideal, this project is huge! 

Thanks for your work,
Dennis