### PR TITLE
fix(sorted): sortedSet remove should not use reference equality

### DIFF
--- a/deno_dist/sorted/set-custom/implementation/immutable.ts
+++ b/deno_dist/sorted/set-custom/implementation/immutable.ts
@@ -432,7 +432,7 @@ export class SortedSetLeaf<T> extends SortedSetNode<T> {
 
     const currentValue = this.entries[entryIndex];
 
-    if (currentValue !== value) return this;
+    if (this.context.comp.compare(currentValue, value) !== 0) return this;
 
     const newEntries = Arr.splice(this.mutateEntries, entryIndex, 1);
     return this.copy(newEntries);

--- a/packages/sorted/src/set-custom/implementation/immutable.mts
+++ b/packages/sorted/src/set-custom/implementation/immutable.mts
@@ -432,7 +432,7 @@ export class SortedSetLeaf<T> extends SortedSetNode<T> {
 
     const currentValue = this.entries[entryIndex];
 
-    if (currentValue !== value) return this;
+    if (this.context.comp.compare(currentValue, value) !== 0) return this;
 
     const newEntries = Arr.splice(this.mutateEntries, entryIndex, 1);
     return this.copy(newEntries);

--- a/packages/sorted/test/sortedset-issues.test.mts
+++ b/packages/sorted/test/sortedset-issues.test.mts
@@ -1,0 +1,14 @@
+import { SortedSet } from '../src/main/index.mjs';
+import { Tuple } from '@rimbu/core';
+
+describe('SortedSet issues fixed by PRs', () => {
+  it('issue #189: remove should not use reference equality', () => {
+    const set1 = SortedSet.of(Tuple.of(1, 'a'), Tuple.of(2, 'b'));
+
+    expect(set1.getAtIndex(0)).toEqual([1, 'a']);
+    expect(set1.has([1, 'a'])).toBe(true);
+
+    const s2 = set1.remove([1, 'a']);
+    expect(s2.size).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #189 

SortedSet remove now uses the context comparator instead of reference equality