### PR TITLE
fix(hashed): fix HashMap using === instead of context.eq for get, addEntry and modifyAt

### DIFF
--- a/deno_dist/hashed/map-custom/implementation/builder.ts
+++ b/deno_dist/hashed/map-custom/implementation/builder.ts
@@ -237,7 +237,7 @@ export class HashMapBlockBuilder<K, V>
 
         const newValue = options.ifExists(currentValue, Token);
 
-        if (newValue === currentValue) {
+        if (Object.is(newValue, currentValue)) {
           return false;
         }
 

--- a/deno_dist/hashed/map-custom/implementation/immutable.ts
+++ b/deno_dist/hashed/map-custom/implementation/immutable.ts
@@ -618,7 +618,7 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
     const token = Symbol();
     const stream = this.stream();
     const foundEntry = stream.find(
-      (entry): boolean => entry[0] === key,
+      (entry): boolean => this.context.eq(entry[0], key),
       undefined,
       token
     );
@@ -629,8 +629,8 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
   }
 
   addEntry(entry: readonly [K, V], hash?: number): HashMapCollision<K, V> {
-    const currentIndex = this.stream().indexWhere(
-      (currentEntry): boolean => currentEntry[0] === entry[0]
+    const currentIndex = this.stream().indexWhere((currentEntry): boolean =>
+      this.context.eq(currentEntry[0], entry[0])
     );
 
     if (undefined === currentIndex) {
@@ -639,7 +639,7 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
 
     return this.copy(
       this.entries.updateAt(currentIndex, (currentEntry): readonly [K, V] => {
-        if (currentEntry[1] === entry[1]) return currentEntry;
+        if (Object.is(currentEntry[1], entry[1])) return currentEntry;
         return entry;
       })
     );
@@ -653,8 +653,8 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
     },
     atKeyHash?: number
   ): HashMap<K, V> | any {
-    const currentIndex = this.stream().indexWhere(
-      (entry): boolean => entry[0] === atKey
+    const currentIndex = this.stream().indexWhere((entry): boolean =>
+      this.context.eq(entry[0], atKey)
     );
 
     if (undefined === currentIndex) {

--- a/packages/hashed/src/map-custom/implementation/builder.mts
+++ b/packages/hashed/src/map-custom/implementation/builder.mts
@@ -237,7 +237,7 @@ export class HashMapBlockBuilder<K, V>
 
         const newValue = options.ifExists(currentValue, Token);
 
-        if (newValue === currentValue) {
+        if (Object.is(newValue, currentValue)) {
           return false;
         }
 

--- a/packages/hashed/src/map-custom/implementation/immutable.mts
+++ b/packages/hashed/src/map-custom/implementation/immutable.mts
@@ -618,7 +618,7 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
     const token = Symbol();
     const stream = this.stream();
     const foundEntry = stream.find(
-      (entry): boolean => entry[0] === key,
+      (entry): boolean => this.context.eq(entry[0], key),
       undefined,
       token
     );
@@ -629,8 +629,8 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
   }
 
   addEntry(entry: readonly [K, V], hash?: number): HashMapCollision<K, V> {
-    const currentIndex = this.stream().indexWhere(
-      (currentEntry): boolean => currentEntry[0] === entry[0]
+    const currentIndex = this.stream().indexWhere((currentEntry): boolean =>
+      this.context.eq(currentEntry[0], entry[0])
     );
 
     if (undefined === currentIndex) {
@@ -639,7 +639,7 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
 
     return this.copy(
       this.entries.updateAt(currentIndex, (currentEntry): readonly [K, V] => {
-        if (currentEntry[1] === entry[1]) return currentEntry;
+        if (Object.is(currentEntry[1], entry[1])) return currentEntry;
         return entry;
       })
     );
@@ -653,8 +653,8 @@ export class HashMapCollision<K, V> extends HashMapNonEmptyBase<K, V> {
     },
     atKeyHash?: number
   ): HashMap<K, V> | any {
-    const currentIndex = this.stream().indexWhere(
-      (entry): boolean => entry[0] === atKey
+    const currentIndex = this.stream().indexWhere((entry): boolean =>
+      this.context.eq(entry[0], atKey)
     );
 
     if (undefined === currentIndex) {

--- a/packages/hashed/test/hashmap-issues.test.mts
+++ b/packages/hashed/test/hashmap-issues.test.mts
@@ -1,0 +1,58 @@
+import { HashMap } from '../src/main/index.mjs';
+
+describe('HashMap issues fixed by PRs', () => {
+  it('issue #186: HashMap "forgets" about colliding keys, unlike HashSet', () => {
+    const hm = HashMap.from([
+      [[6, 29], 'a'],
+      [[2, 91], 'b'],
+    ]);
+    expect(hm.hasKey([6, 29])).toBe(true);
+    expect(hm.hasKey([2, 91])).toBe(true);
+    expect(hm.get([6, 29])).toBe('a');
+    expect(hm.modifyAt([6, 29], { ifExists: () => 'g' }).get([6, 29])).toBe(
+      'g'
+    );
+    expect(hm.removeKey([6, 29]).size).toBe(1);
+
+    const hm2 = HashMap.from([
+      [[6, 30], 'a'],
+      [[2, 91], 'b'],
+    ]);
+    expect(hm2.hasKey([6, 30])).toBe(true);
+    expect(hm2.hasKey([2, 91])).toBe(true);
+    expect(hm2.get([6, 30])).toBe('a');
+    expect(hm2.modifyAt([6, 30], { ifExists: () => 'g' }).get([6, 30])).toBe(
+      'g'
+    );
+    expect(hm2.removeKey([6, 30]).size).toBe(1);
+
+    const hm3 = HashMap.from([
+      [[6, 29], 'c'],
+      [[2, 91], 'd'],
+    ]);
+    expect(hm3.hasKey([6, 29])).toBe(true);
+    expect(hm3.hasKey([2, 91])).toBe(true);
+    expect(hm3.get([6, 29])).toBe('c');
+    expect(hm3.modifyAt([6, 29], { ifExists: () => 'g' }).get([6, 29])).toBe(
+      'g'
+    );
+    expect(hm3.removeKey([6, 29]).size).toBe(1);
+  });
+
+  it('issue #186 for builder: HashMap "forgets" about colliding keys, unlike HashSet', () => {
+    const hm = HashMap.builder<[number, number], string>();
+    hm.addEntries([
+      [[6, 29], 'a'],
+      [[2, 91], 'b'],
+    ]);
+    expect(hm.hasKey([6, 29])).toBe(true);
+    expect(hm.hasKey([2, 91])).toBe(true);
+    expect(hm.get([6, 29])).toBe('a');
+
+    hm.modifyAt([6, 29], { ifExists: () => 'g' });
+    expect(hm.get([6, 29])).toBe('g');
+    hm.removeKey([6, 29]);
+
+    expect(hm.size).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #186 

HashMap now correctly uses the `context.eq` instance to compare keys instead of `===`.