### PR TITLE
Feature/refactor stream

### DIFF
--- a/deno_dist/actor/CHANGELOG.md
+++ b/deno_dist/actor/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.14.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/actor@0.13.1...@rimbu/actor@0.14.0) (2024-01-26)
+
+### Bug Fixes
+
+- **actor:** ensure generateUUID works with both node 18 and node 20 ([4e2448a](https://github.com/rimbu-org/rimbu/commit/4e2448ae7aa816e2b79bbec6f29fca322ccbc463))
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [0.13.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/actor@0.13.0...@rimbu/actor@0.13.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/actor

--- a/deno_dist/actor/main/actor.ts
+++ b/deno_dist/actor/main/actor.ts
@@ -1,4 +1,3 @@
-import { OptLazy } from '../../common/mod.ts';
 import type { Reducer } from '../../stream/mod.ts';
 
 import type { ActionBase } from './internal.ts';
@@ -83,14 +82,15 @@ export namespace Actor {
   }): EnhancedActor {
     const { reducer, middleware, enhancer, actions } = config;
 
-    let reducerState = OptLazy(reducer.init);
-
-    let index = 0;
     let halted = false;
 
     const halt = (): void => {
       halted = true;
     };
+
+    let reducerState = reducer.init(halt);
+
+    let index = 0;
 
     const listeners = new Set<Actor.Listener>();
 
@@ -121,7 +121,7 @@ export namespace Actor {
     const actor: any = {
       getState: (): S => {
         if (STALE_STATE === cacheState) {
-          cacheState = reducer.stateToResult(reducerState);
+          cacheState = reducer.stateToResult(reducerState, index, halted);
         }
 
         return cacheState;

--- a/deno_dist/base/CHANGELOG.md
+++ b/deno_dist/base/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/base@1.1.0...@rimbu/base@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### Performance Improvements
+
+- **base:** export most performant arr methods based on available array methods ([714e66e](https://github.com/rimbu-org/rimbu/commit/714e66ed60289bc5eefff827e7ae167e8131cfb7))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 # [1.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/base@1.0.0...@rimbu/base@1.1.0) (2023-07-29)
 
 ### Features

--- a/deno_dist/bimap/CHANGELOG.md
+++ b/deno_dist/bimap/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimap@1.1.1...@rimbu/bimap@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimap@1.1.0...@rimbu/bimap@1.1.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/bimap

--- a/deno_dist/bimultimap/CHANGELOG.md
+++ b/deno_dist/bimultimap/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimultimap@1.1.1...@rimbu/bimultimap@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimultimap@1.1.0...@rimbu/bimultimap@1.1.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/bimultimap

--- a/deno_dist/channel/CHANGELOG.md
+++ b/deno_dist/channel/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.2.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/channel@0.1.1...@rimbu/channel@0.2.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [0.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/channel@0.1.0...@rimbu/channel@0.1.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/channel

--- a/deno_dist/collection-types/CHANGELOG.md
+++ b/deno_dist/collection-types/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/collection-types@1.1.1...@rimbu/collection-types@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/collection-types@1.1.0...@rimbu/collection-types@1.1.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/collection-types

--- a/deno_dist/collection-types/set-custom/interface/base.ts
+++ b/deno_dist/collection-types/set-custom/interface/base.ts
@@ -120,6 +120,7 @@ export interface VariantSetBase<
    * - `halt`: a function that, when called, ensures no next elements are passed
    * @param options - (optional) an object containing the following properties:<br/>
    * - negate: (default: false) when true will negate the predicate
+   * @note if the predicate is a type guard, the return type is automatically inferred
    * @example
    * ```ts
    * HashSet.of(1, 2, 3).filter(value < 3).toArray()

--- a/deno_dist/collection-types/set-custom/interface/base.ts
+++ b/deno_dist/collection-types/set-custom/interface/base.ts
@@ -126,6 +126,14 @@ export interface VariantSetBase<
    * // => [1, 2]
    * ```
    */
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options?: { negate?: false | undefined }
+  ): WithElem<Tp, TF>['normal'];
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options: { negate: true }
+  ): WithElem<Tp, Exclude<T, TF>>['normal'];
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
     options?: { negate?: boolean }

--- a/deno_dist/common/CHANGELOG.md
+++ b/deno_dist/common/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/common@1.1.0...@rimbu/common@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 # [1.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/common@1.0.0...@rimbu/common@1.1.0) (2023-07-29)
 
 ### Features

--- a/deno_dist/core/CHANGELOG.md
+++ b/deno_dist/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/core@1.1.3...@rimbu/core@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/core@1.1.2...@rimbu/core@1.1.3) (2023-12-25)
 
 **Note:** Version bump only for package @rimbu/core

--- a/deno_dist/deep/CHANGELOG.md
+++ b/deno_dist/deep/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/deep@1.1.0...@rimbu/deep@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 # [1.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/deep@1.0.0...@rimbu/deep@1.1.0) (2023-07-29)
 
 ### Features

--- a/deno_dist/graph/CHANGELOG.md
+++ b/deno_dist/graph/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/graph@1.1.1...@rimbu/graph@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/graph@1.1.0...@rimbu/graph@1.1.1) (2023-12-09)
 
 ### Bug Fixes

--- a/deno_dist/hashed/CHANGELOG.md
+++ b/deno_dist/hashed/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/hashed@1.1.1...@rimbu/hashed@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/hashed@1.1.0...@rimbu/hashed@1.1.1) (2023-12-09)
 
 ### Bug Fixes

--- a/deno_dist/hashed/set-custom/implementation/immutable.ts
+++ b/deno_dist/hashed/set-custom/implementation/immutable.ts
@@ -115,8 +115,8 @@ export abstract class HashSetNonEmptyBase<T>
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { negate?: boolean } = {}
-  ): HashSet<T> {
+    options: { negate?: boolean | undefined } = {}
+  ): any {
     const builder = this.context.builder();
 
     builder.addAll(this.stream().filter(pred, options));

--- a/deno_dist/list/CHANGELOG.md
+++ b/deno_dist/list/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/list@1.1.1...@rimbu/list@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/list@1.1.0...@rimbu/list@1.1.1) (2023-12-09)
 
 ### Bug Fixes

--- a/deno_dist/list/custom/implementation/empty.ts
+++ b/deno_dist/list/custom/implementation/empty.ts
@@ -85,7 +85,7 @@ export class Empty<T = any> extends EmptyBase implements List<T> {
     return this;
   }
 
-  filter(): this {
+  filter(): any {
     return this;
   }
 

--- a/deno_dist/list/custom/implementation/leaf/non-empty.ts
+++ b/deno_dist/list/custom/implementation/leaf/non-empty.ts
@@ -195,8 +195,12 @@ export abstract class ListNonEmptyBase<T>
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { range?: IndexRange; reversed?: boolean; negate?: boolean } = {}
-  ): List<T> {
+    options: {
+      range?: IndexRange | undefined;
+      reversed?: boolean | undefined;
+      negate?: boolean | undefined;
+    } = {}
+  ): any {
     const { range, reversed = false, negate = false } = options;
 
     const stream =

--- a/deno_dist/list/main/interface.ts
+++ b/deno_dist/list/main/interface.ts
@@ -404,6 +404,22 @@ export interface List<T> extends FastIterable<T> {
    *   .filter((_, i) => i > 1, undefined, true)      // -> List(1, 0)
    * ```
    */
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options?: {
+      range?: IndexRange;
+      reversed?: boolean;
+      negate?: false | undefined;
+    }
+  ): List<TF>;
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options: {
+      range?: IndexRange;
+      reversed?: boolean;
+      negate: true;
+    }
+  ): List<Exclude<T, TF>>;
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
     options?: { range?: IndexRange; reversed?: boolean; negate?: boolean }

--- a/deno_dist/list/main/interface.ts
+++ b/deno_dist/list/main/interface.ts
@@ -393,6 +393,7 @@ export interface List<T> extends FastIterable<T> {
    * @param options - (optional) an object containing the following properties:<br/>
    * - range: (optional) the range of the list to include in the filtering process<br/>
    * - reversed: (default: false) if true reverses the elements within the given range
+   * @note if the predicate is a type guard, the return type is automatically inferred
    * @example
    * ```ts
    * List.of(0, 1, 2, 3).filter(v => v < 2)           // -> List(0, 1)

--- a/deno_dist/multimap/CHANGELOG.md
+++ b/deno_dist/multimap/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/multimap@1.1.1...@rimbu/multimap@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/multimap@1.1.0...@rimbu/multimap@1.1.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/multimap

--- a/deno_dist/multiset/CHANGELOG.md
+++ b/deno_dist/multiset/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/multiset@1.1.1...@rimbu/multiset@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/multiset@1.1.0...@rimbu/multiset@1.1.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/multiset

--- a/deno_dist/multiset/custom/implementation/base.ts
+++ b/deno_dist/multiset/custom/implementation/base.ts
@@ -342,7 +342,7 @@ export class MultiSetNonEmpty<
 
   filterEntries(
     pred: (entry: readonly [T, number], index: number) => boolean,
-    options: { negate?: boolean } = {}
+    options: { negate?: boolean | undefined } = {}
   ): TpG['normal'] {
     const builder = this.context.builder();
 

--- a/deno_dist/multiset/custom/interface/base.ts
+++ b/deno_dist/multiset/custom/interface/base.ts
@@ -194,6 +194,7 @@ export interface VariantMultiSetBase<
    * - `halt`: a function that, when called, ensures no next entries are passed
    * @param options - (optional) an object containing the following properties:<br/>
    * - negate: (default: false) when true will negate the predicate
+   * @note if the predicate is a type guard, the return type is automatically inferred
    * @example
    * ```ts
    * HashMultiSet.of(1, 2, 2, 3)

--- a/deno_dist/multiset/custom/interface/base.ts
+++ b/deno_dist/multiset/custom/interface/base.ts
@@ -202,6 +202,14 @@ export interface VariantMultiSetBase<
    * // => [[2, 2]]
    * ```
    */
+  filterEntries<TF extends T>(
+    pred: (entry: readonly [T, number], index: number) => entry is [TF, number],
+    options?: { negate?: false | undefined }
+  ): WithElem<Tp, TF>['normal'];
+  filterEntries<TF extends T>(
+    pred: (entry: readonly [T, number], index: number) => entry is [TF, number],
+    options: { negate: true }
+  ): WithElem<Tp, Exclude<T, TF>>['normal'];
   filterEntries(
     pred: (entry: readonly [T, number], index: number) => boolean,
     options?: { negate?: boolean }

--- a/deno_dist/ordered/CHANGELOG.md
+++ b/deno_dist/ordered/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/ordered@1.1.1...@rimbu/ordered@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/ordered@1.1.0...@rimbu/ordered@1.1.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/ordered

--- a/deno_dist/ordered/set-custom/implementation/non-empty.ts
+++ b/deno_dist/ordered/set-custom/implementation/non-empty.ts
@@ -105,13 +105,13 @@ export class OrderedSetNonEmpty<
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { negate?: boolean } = {}
-  ): TpG['normal'] {
+    options: { negate?: boolean | undefined } = {}
+  ): any {
     const builder = this.context.builder<T>();
 
     builder.addAll(this.stream().filter(pred, options));
 
-    if (builder.size === this.size) return this as any;
+    if (builder.size === this.size) return this;
 
     return builder.build();
   }

--- a/deno_dist/proximity/CHANGELOG.md
+++ b/deno_dist/proximity/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/proximity@1.1.1...@rimbu/proximity@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/proximity@1.1.0...@rimbu/proximity@1.1.1) (2023-12-09)
 
 ### Bug Fixes

--- a/deno_dist/reactor/CHANGELOG.md
+++ b/deno_dist/reactor/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.14.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/reactor@0.13.1...@rimbu/reactor@0.14.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [0.13.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/reactor@0.13.0...@rimbu/reactor@0.13.1) (2023-12-09)
 
 **Note:** Version bump only for package @rimbu/reactor

--- a/deno_dist/sorted/CHANGELOG.md
+++ b/deno_dist/sorted/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/sorted@1.1.1...@rimbu/sorted@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/sorted@1.1.0...@rimbu/sorted@1.1.1) (2023-12-09)
 
 ### Bug Fixes

--- a/deno_dist/sorted/set-custom/implementation/immutable.ts
+++ b/deno_dist/sorted/set-custom/implementation/immutable.ts
@@ -215,8 +215,8 @@ export abstract class SortedSetNode<T>
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { negate?: boolean } = {}
-  ): SortedSet<T> {
+    options: { negate?: boolean | undefined } = {}
+  ): any {
     const builder = this.context.builder();
 
     builder.addAll(this.stream().filter(pred, options));

--- a/deno_dist/spy/CHANGELOG.md
+++ b/deno_dist/spy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.7.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/spy@0.6.0...@rimbu/spy@0.7.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 # [0.6.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/spy@0.5.0...@rimbu/spy@0.6.0) (2023-07-29)
 
 ### Features

--- a/deno_dist/stream/CHANGELOG.md
+++ b/deno_dist/stream/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/stream@1.1.1...@rimbu/stream@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/stream@1.1.0...@rimbu/stream@1.1.1) (2023-12-09)
 
 ### Bug Fixes

--- a/deno_dist/stream/async-custom/async-stream-custom.ts
+++ b/deno_dist/stream/async-custom/async-stream-custom.ts
@@ -10,40 +10,31 @@ import {
   type ToJSON,
 } from '../../common/mod.ts';
 
-import type { StreamSource } from '../../stream/mod.ts';
-import type {
-  AsyncFastIterator,
-  AsyncStream,
-  AsyncStreamSource,
+import { Transformer, type StreamSource } from '../../stream/mod.ts';
+import {
+  AsyncReducer,
   AsyncTransformer,
+  type AsyncFastIterator,
+  type AsyncStream,
+  type AsyncStreamSource,
 } from '../../stream/async/index.ts';
 import {
   AsyncAppendIterator,
   AsyncCollectIterator,
   AsyncConcatIterator,
-  AsyncDistinctPreviousIterator,
   AsyncDropIterator,
   AsyncDropWhileIterator,
   AsyncFilterIterator,
   AsyncFilterPureIterator,
-  AsyncFlatMapIterator,
-  AsyncFoldIterator,
   AsyncIndexedIterator,
-  AsyncIndicesOfIterator,
-  AsyncIndicesWhereIterator,
-  AsyncIntersperseIterator,
   AsyncMapIterator,
   AsyncMapPureIterator,
   AsyncOfIterator,
   AsyncPrependIterator,
   AsyncReduceIterator,
   AsyncRepeatIterator,
-  AsyncSplitOnIterator,
-  AsyncSplitWhereIterator,
   AsyncTakeIterator,
-  AsyncTakeWhileIterator,
   AsyncUnfoldIterator,
-  AsyncWindowIterator,
   AsyncZipAllWithItererator,
   AsyncZipWithIterator,
   FromAsyncIterator,
@@ -54,13 +45,12 @@ import {
   emptyAsyncFastIterator,
   isAsyncFastIterator,
   type AsyncStreamConstructors,
-  AsyncSplitOnSeqIterator,
+  AsyncTransformerFastIterator,
 } from '../../stream/async-custom/index.ts';
 import {
   StreamConstructorsImpl,
   isEmptyStreamSourceInstance,
 } from '../../stream/custom/index.ts';
-import { AsyncReducer } from '../../stream/async/index.ts';
 
 export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   abstract [Symbol.asyncIterator](): AsyncFastIterator<T>;
@@ -170,6 +160,27 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     return new AsyncIndexedStream<T>(this, startIndex);
   }
 
+  filter(
+    pred: (value: T, index: number, halt: () => void) => MaybePromise<boolean>,
+    options: { negate?: boolean | undefined } = {}
+  ): any {
+    const { negate = false } = options;
+
+    return new AsyncFilterStream<T>(this, pred, negate);
+  }
+
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+
+    return new AsyncFilterPureStream<T, A>(this, pred, args, negate);
+  }
+
   map<T2>(
     mapFun: (value: T, index: number) => MaybePromise<T2>
   ): AsyncStream<T2> {
@@ -183,6 +194,10 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     return new AsyncMapPureStream<T, A, T2>(this, mapFun, args);
   }
 
+  collect<R>(collectFun: AsyncCollectFun<T, R>): AsyncStream<R> {
+    return new AsyncCollectStream<T, R>(this, collectFun);
+  }
+
   flatMap<T2>(
     flatMapFun: (
       value: T,
@@ -190,7 +205,7 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => AsyncStreamSource<T2>
   ): AsyncStream<T2> {
-    return new AsyncFlatMapStream<T, T2>(this, flatMapFun);
+    return this.transform(AsyncTransformer.flatMap(flatMapFun));
   }
 
   flatZip<T2>(
@@ -200,43 +215,11 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => AsyncStreamSource<T2>
   ): AsyncStream<[T, T2]> {
-    return this.flatMap((value, index, halt) =>
-      fromAsyncStreamSource(flatMapFun(value, index, halt)).map((result) => [
-        value,
-        result,
-      ])
-    );
+    return this.transform(AsyncTransformer.flatZip(flatMapFun));
   }
 
-  transform<R>(
-    transformer: AsyncReducer<T, AsyncStreamSource<R>>
-  ): AsyncStream<R> {
-    return AsyncStreamConstructorsImpl.flatten(this.reduceStream(transformer));
-  }
-
-  filter(
-    pred: (value: T, index: number, halt: () => void) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
-  ): AsyncStream<T> {
-    const { negate = false } = options;
-
-    return new AsyncFilterStream<T>(this, pred, negate);
-  }
-
-  filterPure<A extends readonly unknown[]>(
-    options: {
-      pred: (value: T, ...args: A) => MaybePromise<boolean>;
-      negate?: boolean;
-    },
-    ...args: A
-  ): AsyncStream<T> {
-    const { pred, negate = false } = options;
-
-    return new AsyncFilterPureStream<T, A>(this, pred, args, negate);
-  }
-
-  collect<R>(collectFun: AsyncCollectFun<T, R>): AsyncStream<R> {
-    return new AsyncCollectStream<T, R>(this, collectFun);
+  transform<R>(transformer: AsyncTransformer.Accept<T, R>): AsyncStream<R> {
+    return new AsyncTransformerStream(this, transformer);
   }
 
   async first<O>(otherwise?: AsyncOptLazy<O>): Promise<T | O> {
@@ -315,7 +298,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     const iterator = this[Symbol.asyncIterator]();
 
     try {
-      while (done !== (await iterator.fastNext(done))) result++;
+      while (done !== (await iterator.fastNext(done))) {
+        result++;
+      }
 
       return result;
     } catch (err) {
@@ -338,7 +323,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       let current: T | typeof done;
 
       while (done !== (current = await iterator.fastNext(done))) {
-        if (eq(value, current) !== negate) result++;
+        if (eq(value, current) !== negate) {
+          result++;
+        }
       }
 
       return result;
@@ -351,8 +338,8 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   async find<O>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: {
-      occurrance?: number;
-      negate?: boolean;
+      occurrance?: number | undefined;
+      negate?: boolean | undefined;
       otherwise?: AsyncOptLazy<O>;
     } = {}
   ): Promise<T | O> {
@@ -413,18 +400,14 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     pred: (value: T) => MaybePromise<boolean>,
     options: { negate?: boolean } = {}
   ): AsyncStream<number> {
-    const { negate = false } = options;
-
-    return new AsyncIndicesWhereStream<T>(this, pred, negate);
+    return this.transform(AsyncTransformer.indicesWhere(pred, options));
   }
 
   indicesOf(
     searchValue: T,
     options: { eq?: Eq<T>; negate?: boolean } = {}
   ): AsyncStream<number> {
-    const { eq = Eq.objectIs, negate = false } = options;
-
-    return new AsyncIndicesOfStream<T>(this, searchValue, eq, negate);
+    return this.transform(Transformer.indicesOf(searchValue, options));
   }
 
   async indexWhere(
@@ -433,7 +416,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   ): Promise<number | undefined> {
     const { occurrance = 1, negate = false } = options;
 
-    if (occurrance <= 0) return undefined;
+    if (occurrance <= 0) {
+      return undefined;
+    }
 
     const done = Symbol('Done');
     let value: T | typeof done;
@@ -523,7 +508,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   ): Promise<boolean> {
     const { amount = 1 } = options;
 
-    if (amount <= 0) return true;
+    if (amount <= 0) {
+      return true;
+    }
 
     const { eq = Eq.objectIs, negate = false } = options;
 
@@ -537,38 +524,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     source: AsyncStreamSource.NonEmpty<T>,
     options: { eq?: Eq<T>; negate?: boolean } = {}
   ): Promise<boolean> {
-    const { eq = Eq.objectIs, negate = false } = options;
-
-    const iterator = this[Symbol.asyncIterator]();
-    const sourceStream = fromAsyncStreamSource(source);
-    let sourceIterator = sourceStream[Symbol.asyncIterator]();
-
-    const done = Symbol('Done');
-
-    let value: T | typeof done = done;
-
-    try {
-      while (true) {
-        const sourceValue = await sourceIterator.fastNext(done);
-
-        if (done === sourceValue) {
-          return true;
-        }
-
-        value = await iterator.fastNext(done);
-        if (done === value) {
-          return false;
-        }
-
-        if (eq(sourceValue, value) === negate) {
-          sourceIterator = sourceStream[Symbol.asyncIterator]();
-        }
-      }
-    } finally {
-      if (done !== value) {
-        await closeIters(iterator);
-      }
-    }
+    return (this as AsyncStream<T>).reduce(
+      AsyncReducer.containsSlice(source, options)
+    );
   }
 
   takeWhile(
@@ -577,7 +535,15 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   ): AsyncStream<T> {
     const { negate = false } = options;
 
-    return new AsyncTakeWhileStream(this, pred, negate);
+    return this.filter(async (value, index, halt) => {
+      const result = (await pred(value, index)) !== negate;
+
+      if (!result) {
+        halt();
+      }
+
+      return result;
+    });
   }
 
   dropWhile(
@@ -590,13 +556,17 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   }
 
   take(amount: number): AsyncStream<T> {
-    if (amount <= 0) return emptyAsyncStream;
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
 
     return new AsyncTakeStream<T>(this, amount);
   }
 
   drop(amount: number): AsyncStream<T> {
-    if (amount <= 0) return this;
+    if (amount <= 0) {
+      return this;
+    }
 
     return new AsyncDropStream<T>(this, amount);
   }
@@ -679,11 +649,11 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   }
 
   intersperse(sep: AsyncStreamSource<T>): AsyncStream<T> {
-    if (isEmptyAsyncStreamSourceInstance(sep)) return this;
+    if (isEmptyAsyncStreamSourceInstance(sep)) {
+      return this;
+    }
 
-    const sepStream = fromAsyncStreamSource(sep);
-
-    return new AsyncIntersperseStream<T>(this, sepStream);
+    return this.transform(AsyncTransformer.intersperse(sep));
   }
 
   async join({
@@ -729,68 +699,69 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   splitWhere<R>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: {
-      negate?: boolean;
-      collector?: AsyncReducer<T, R> | undefined;
+      negate?: boolean | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
   ): AsyncStream<R> {
-    const {
-      negate = false,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
-
-    return new AsyncSplitWhereStream<T, R>(this, pred, negate, collector);
+    return this.transform(AsyncTransformer.splitWhere(pred, options));
   }
 
   splitOn<R>(
     sepElem: T,
     options: {
-      eq?: Eq<T>;
-      negate?: boolean;
-      collector?: AsyncReducer<T, R> | undefined;
+      eq?: Eq<T> | undefined;
+      negate?: boolean | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
   ): AsyncStream<R> {
-    const {
-      eq = Eq.objectIs,
-      negate = false,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
-
-    return new AsyncSplitOnStream<T, R>(this, sepElem, eq, negate, collector);
+    return this.transform(AsyncTransformer.splitOn(sepElem, options));
   }
 
-  splitOnSeq<R>(
-    sepSeq: AsyncStreamSource<T>,
-    options: { eq?: Eq<T>; collector?: AsyncReducer<T, R> | undefined } = {}
+  splitOnSlice<R>(
+    sepSlice: AsyncStreamSource<T>,
+    options: {
+      eq?: Eq<T> | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
+    } = {}
   ): AsyncStream<R> {
-    const {
-      eq = Object.is,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
-
-    return new AsyncSplitOnSeq<T, R>(this, sepSeq, eq, collector);
+    return this.transform(AsyncTransformer.splitOnSlice(sepSlice, options));
   }
 
   distinctPrevious(
-    options: { eq?: Eq<T>; negate?: boolean } = {}
+    options: { eq?: Eq<T> | undefined; negate?: boolean | undefined } = {}
   ): AsyncStream<T> {
-    const { eq = Eq.objectIs, negate = false } = options;
-
-    return new AsyncDistinctPreviousStream<T>(this, eq, negate);
+    return this.transform(Transformer.distinctPrevious(options));
   }
 
   window<R>(
     windowSize: number,
     options: {
-      skipAmount?: number;
-      collector?: AsyncReducer<T, R> | undefined;
+      skipAmount?: number | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
   ): AsyncStream<R> {
-    const {
-      skipAmount = windowSize,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
+    return this.transform(AsyncTransformer.window(windowSize, options as any));
+  }
 
-    return new AsyncWindowStream<T, R>(this, windowSize, skipAmount, collector);
+  partition(
+    pred: (value: T, index: number) => MaybePromise<boolean>,
+    options: {
+      collectorTrue?: any;
+      collectorFalse?: any;
+    } = {}
+  ): Promise<[any, any]> {
+    return (this as AsyncStream<T>).reduce<[any, any]>(
+      AsyncReducer.partition(pred, options)
+    );
+  }
+
+  groupBy<K, R>(
+    valueToKey: (value: T, index: number) => MaybePromise<K>,
+    options: { collector?: AsyncReducer.Accept<[K, T], R> | undefined } = {}
+  ): Promise<R> {
+    return (this as AsyncStream<T>).reduce(
+      AsyncReducer.groupBy<T, K, R>(valueToKey, options as any)
+    );
   }
 
   async fold<R>(
@@ -802,9 +773,7 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => MaybePromise<R>
   ): Promise<R> {
-    return this.reduce(
-      AsyncReducer.createOutput(() => AsyncOptLazy.toMaybePromise(init), next)
-    );
+    return (this as AsyncStream<T>).reduce(AsyncReducer.fold(init, next));
   }
 
   foldStream<R>(
@@ -816,18 +785,15 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => MaybePromise<R>
   ): AsyncStream<R> {
-    return new AsyncFromStream(
-      (): AsyncFastIterator<R> =>
-        new AsyncFoldIterator(this[Symbol.asyncIterator](), init, next)
-    );
+    return (this as AsyncStream<T>).reduceStream(AsyncReducer.fold(init, next));
   }
 
   async reduce<const S extends AsyncReducer.CombineShape<T>>(
     shape: S & AsyncReducer.CombineShape<T>
   ): Promise<AsyncReducer.CombineResult<S>> {
-    const reducerInstance = AsyncReducer.combine(
+    const reducerInstance = (await AsyncReducer.combine<T, S>(
       shape
-    ).compile() as AsyncReducer.Instance<T, AsyncReducer.CombineResult<S>>;
+    ).compile()) as AsyncReducer.Instance<T, AsyncReducer.CombineResult<S>>;
 
     const done = Symbol('Done');
     let value: T | typeof done = done;
@@ -843,18 +809,15 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
 
       return await reducerInstance.getOutput();
     } finally {
+      await closeIters(iter);
       await reducerInstance.onClose();
-
-      if (done !== value) {
-        await closeIters(iter);
-      }
     }
   }
 
   reduceStream<const S extends AsyncReducer.CombineShape<T>>(
     shape: S & AsyncReducer.CombineShape<T>
   ): AsyncStream<AsyncReducer.CombineResult<S>> {
-    const reducer = AsyncReducer.combine(shape) as AsyncReducer<
+    const reducer = AsyncReducer.combine<T, S>(shape) as AsyncReducer<
       T,
       AsyncReducer.CombineResult<S>
     >;
@@ -924,6 +887,105 @@ class AsyncPrependStream<T> extends AsyncStreamBase<T> {
   async count(): Promise<number> {
     return (await this.source.count()) + 1;
   }
+
+  async forEach(
+    f: (value: T, index: number, halt: () => void) => MaybePromise<void>,
+    options: { state?: TraverseState } = {}
+  ): Promise<void> {
+    const { state = TraverseState() } = options;
+
+    if (state.halted) return;
+
+    await f(
+      await AsyncOptLazy.toMaybePromise(this.item),
+      state.nextIndex(),
+      state.halt
+    );
+
+    if (state.halted) return;
+
+    await this.source.forEach(f, { state });
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    return new AsyncPrependStream(
+      this.source.mapPure(mapFun, ...args),
+      async () => mapFun(await AsyncOptLazy.toMaybePromise(this.item), ...args)
+    );
+  }
+
+  take(amount: number): AsyncStream<T> {
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    if (amount === 1) {
+      return AsyncStreamConstructorsImpl.of(this.item);
+    }
+
+    return new AsyncPrependStream(this.source.take(amount - 1), this.item);
+  }
+
+  drop(amount: number): AsyncStream<T> {
+    if (amount <= 0) {
+      return this;
+    }
+
+    if (amount === 1) {
+      return this.source;
+    }
+
+    return this.source.drop(amount - 1);
+  }
+
+  async minBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.minBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) <= 0 ? result : itemValue;
+  }
+
+  async maxBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.maxBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) > 0 ? result : itemValue;
+  }
+
+  async join({
+    sep = '',
+    start = '',
+    end = '',
+    valueToString = String,
+  } = {}): Promise<string> {
+    return this.source.join({
+      sep,
+      start: `${start}${valueToString(
+        await AsyncOptLazy.toMaybePromise(this.item)
+      )}`,
+      end,
+      valueToString,
+    });
+  }
+
+  async toArray(): Promise<T[]> {
+    const result = await this.source.toArray();
+    result.unshift(await AsyncOptLazy.toMaybePromise(this.item));
+    return result;
+  }
 }
 
 class AsyncAppendStream<T> extends AsyncStreamBase<T> {
@@ -942,12 +1004,87 @@ class AsyncAppendStream<T> extends AsyncStreamBase<T> {
     return this.source.first(this.item);
   }
 
-  async last(): Promise<T> {
+  last(): Promise<T> {
     return AsyncOptLazy.toPromise(this.item);
   }
 
   async count(): Promise<number> {
     return (await this.source.count()) + 1;
+  }
+
+  async forEach(
+    f: (value: T, index: number, halt: () => void) => MaybePromise<void>,
+    options: { state?: TraverseState } = {}
+  ): Promise<void> {
+    const { state = TraverseState() } = options;
+
+    if (state.halted) return;
+
+    await this.source.forEach(f, { state });
+
+    if (state.halted) return;
+
+    await f(
+      await AsyncOptLazy.toMaybePromise(this.item),
+      state.nextIndex(),
+      state.halt
+    );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    return new AsyncAppendStream(
+      this.source.mapPure(mapFun, ...args),
+      async () => mapFun(await AsyncOptLazy.toMaybePromise(this.item), ...args)
+    );
+  }
+
+  async minBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.minBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) <= 0 ? result : itemValue;
+  }
+
+  async maxBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.maxBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) > 0 ? result : itemValue;
+  }
+
+  async join({
+    sep = '',
+    start = '',
+    end = '',
+    valueToString = String,
+  } = {}): Promise<string> {
+    return this.source.join({
+      sep,
+      start,
+      end: `${valueToString(
+        await AsyncOptLazy.toMaybePromise(this.item)
+      )}${end}`,
+      valueToString,
+    });
+  }
+
+  async toArray(): Promise<T[]> {
+    const result = await this.source.toArray();
+    result.push(await AsyncOptLazy.toMaybePromise(this.item));
+    return result;
   }
 }
 
@@ -1018,6 +1155,22 @@ class AsyncMapStream<T, T2> extends AsyncStreamBase<T2> {
       mapFun(await this.mapFun(value, index), index)
     );
   }
+
+  take(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    return new AsyncMapStream(this.source.take(amount), this.mapFun);
+  }
+
+  drop(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return this;
+    }
+
+    return new AsyncMapStream(this.source.drop(amount), this.mapFun);
+  }
 }
 
 class AsyncMapPureStream<
@@ -1068,25 +1221,40 @@ class AsyncMapPureStream<
     if (done === value) return AsyncOptLazy.toPromise(otherwise!);
     return this.mapFun(value, ...this.args);
   }
-}
 
-class AsyncFlatMapStream<T, T2> extends AsyncStreamBase<T2> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly flatmapFun: (
-      value: T,
-      index: number,
-      halt: () => void
-    ) => AsyncStreamSource<T2>
-  ) {
-    super();
+  mapPure<T3, A2 extends readonly unknown[]>(
+    mapFun: (value: T2, ...args: A2) => MaybePromise<T3>,
+    ...args: A2
+  ): AsyncStream<T3> {
+    return new AsyncMapPureStream<T, A2, T3>(
+      this.source,
+      async (value, ...args) =>
+        mapFun(await this.mapFun(value, ...this.args), ...args),
+      args
+    );
   }
 
-  [Symbol.asyncIterator](): AsyncFastIterator<T2> {
-    return new AsyncFlatMapIterator<T, T2>(
-      this.source,
-      this.flatmapFun,
-      asyncStreamSourceHelpers
+  take(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    return new AsyncMapPureStream(
+      this.source.take(amount),
+      this.mapFun,
+      this.args
+    );
+  }
+
+  drop(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return this;
+    }
+
+    return new AsyncMapPureStream(
+      this.source.drop(amount),
+      this.mapFun,
+      this.args
     );
   }
 }
@@ -1094,7 +1262,7 @@ class AsyncFlatMapStream<T, T2> extends AsyncStreamBase<T2> {
 class AsyncConcatStream<T> extends AsyncStreamBase<T> {
   constructor(
     readonly source: AsyncStream<T>,
-    readonly others: AsyncStreamSource<T>[]
+    readonly otherSources: AsyncStreamSource<T>[]
   ) {
     super();
   }
@@ -1102,25 +1270,137 @@ class AsyncConcatStream<T> extends AsyncStreamBase<T> {
   [Symbol.asyncIterator](): AsyncFastIterator<T> {
     return new AsyncConcatIterator(
       this.source,
-      this.others,
+      this.otherSources,
       asyncStreamSourceHelpers
     );
   }
-}
 
-class AsyncIntersperseStream<T> extends AsyncStreamBase<T> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly sepStream: AsyncStream<T>
-  ) {
-    super();
+  async forEach(
+    f: (value: T, index: number, halt: () => void) => MaybePromise<void>,
+    options: { state?: TraverseState } = {}
+  ): Promise<void> {
+    const { state = TraverseState() } = options;
+
+    if (state.halted) return;
+
+    await this.source.forEach(f, { state });
+
+    let sourceIndex = -1;
+    const sources = this.otherSources;
+    const length = sources.length;
+
+    while (!state.halted && ++sourceIndex < length) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        await fromAsyncStreamSource(source).forEach(f, { state });
+      }
+    }
   }
 
-  [Symbol.asyncIterator](): AsyncFastIterator<T> {
-    return new AsyncIntersperseIterator(
-      this.source[Symbol.asyncIterator](),
-      this.sepStream
+  async forEachPure<A extends readonly unknown[]>(
+    f: (value: T, ...args: A) => MaybePromise<void>,
+    ...args: A
+  ): Promise<void> {
+    await this.source.forEachPure(f, ...args);
+
+    let sourceIndex = -1;
+    const sources = this.otherSources;
+    const length = sources.length;
+
+    while (++sourceIndex < length) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        await fromAsyncStreamSource(source).forEachPure(f, ...args);
+      }
+    }
+  }
+
+  async last<O>(otherwise?: AsyncOptLazy<O>): Promise<T | O> {
+    const sources = this.otherSources;
+    let sourceIndex = sources.length;
+
+    while (--sourceIndex >= 0) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        const done = Symbol('Done');
+        const value = await fromAsyncStreamSource(source).last(done);
+        if (done !== value) return value;
+      }
+    }
+
+    return this.source.last(otherwise!);
+  }
+
+  async count(): Promise<number> {
+    let result = await this.source.count();
+
+    const sources = this.otherSources;
+    const length = sources.length;
+    let sourceIndex = -1;
+
+    while (++sourceIndex < length) {
+      const source = sources[sourceIndex];
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        result += await fromAsyncStreamSource(source).count();
+      }
+    }
+
+    return result;
+  }
+
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    return new AsyncConcatStream(
+      this.source.filterPure(options, ...args),
+      this.otherSources.map((source) =>
+        fromAsyncStreamSource(source).filterPure(options, ...args)
+      )
     );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    return new AsyncConcatStream(
+      this.source.mapPure(mapFun, ...args),
+      this.otherSources.map((source) =>
+        fromAsyncStreamSource(source).mapPure(mapFun, ...args)
+      )
+    );
+  }
+
+  concat<T2>(...others2: AsyncStreamSource<T2>[]): any {
+    return new AsyncConcatStream<T | T2>(
+      this.source,
+      (this.otherSources as AsyncStreamSource<T | T2>[]).concat(others2)
+    );
+  }
+
+  async toArray(): Promise<T[]> {
+    let result: T[] = await this.source.toArray();
+
+    let sourceIndex = -1;
+    const sources = this.otherSources;
+    const length = sources.length;
+
+    while (++sourceIndex < length) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        result = result.concat(await fromAsyncStreamSource(source).toArray());
+      }
+    }
+
+    return result;
   }
 }
 
@@ -1145,13 +1425,36 @@ class AsyncFilterStream<T> extends AsyncStreamBase<T> {
     );
   }
 
-  filter(
-    pred: (value: T, index: number, halt: () => void) => MaybePromise<boolean>
-  ): AsyncStream<T> {
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+    const { pred: thisPred, negate: thisNegate } = this;
+
     return new AsyncFilterStream(
       this.source,
-      async (v, i, halt) =>
-        (await this.pred(v, i, halt)) && (await pred(v, i, halt))
+      async (value, index, halt) =>
+        (await thisPred(value, index, halt)) !== thisNegate &&
+        (await pred(value, ...args)) !== negate
+    );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    const { pred, negate } = this;
+
+    return new AsyncCollectStream(
+      this.source,
+      async (value, index, skip, halt) =>
+        (await pred(value, index, halt)) !== negate
+          ? mapFun(value, ...args)
+          : skip
     );
   }
 }
@@ -1177,6 +1480,44 @@ class AsyncFilterPureStream<
       this.negate
     );
   }
+
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+
+    const thisPred = this.pred;
+    const thisArgs = this.args;
+    const thisNegate = this.negate;
+
+    return new AsyncFilterPureStream(
+      this.source,
+      async (value, ...args) => {
+        return (
+          (await thisPred(value, ...thisArgs)) !== thisNegate &&
+          (await pred(value, ...args)) !== negate
+        );
+      },
+      args
+    );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    const { pred, negate, args: thisArgs } = this;
+
+    return new AsyncCollectStream(this.source, async (value, _, skip) =>
+      (await pred(value, ...thisArgs)) !== negate
+        ? mapFun(value, ...args)
+        : skip
+    );
+  }
 }
 
 class AsyncCollectStream<T, R> extends AsyncStreamBase<R> {
@@ -1193,60 +1534,48 @@ class AsyncCollectStream<T, R> extends AsyncStreamBase<R> {
       this.collectFun
     );
   }
-}
 
-class AsyncIndicesWhereStream<T> extends AsyncStreamBase<number> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly pred: (value: T) => MaybePromise<boolean>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: R, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+    const { collectFun } = this;
 
-  [Symbol.asyncIterator](): AsyncFastIterator<number> {
-    return new AsyncIndicesWhereIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.pred,
-      this.negate
+    return new AsyncCollectStream(
+      this.source,
+      async (value, index, skip, halt) => {
+        const result = await collectFun(value, index, skip, halt);
+
+        if (skip === result || (await pred(result, ...args)) === negate) {
+          return skip;
+        }
+
+        return result;
+      }
     );
   }
-}
 
-class AsyncIndicesOfStream<T> extends AsyncStreamBase<number> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly searchValue: T,
-    readonly eq: Eq<T>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: R, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    const { collectFun } = this;
 
-  [Symbol.asyncIterator](): AsyncFastIterator<number> {
-    return new AsyncIndicesOfIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.searchValue,
-      this.eq,
-      this.negate
-    );
-  }
-}
+    return new AsyncCollectStream(
+      this.source,
+      async (value, index, skip, halt) => {
+        const result = await collectFun(value, index, skip, halt);
 
-class AsyncTakeWhileStream<T> extends AsyncStreamBase<T> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly pred: (value: T, index: number) => MaybePromise<boolean>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
+        if (skip === result) {
+          return skip;
+        }
 
-  [Symbol.asyncIterator](): AsyncFastIterator<T> {
-    return new AsyncTakeWhileIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.pred,
-      this.negate
+        return mapFun(result, ...args);
+      }
     );
   }
 }
@@ -1282,7 +1611,14 @@ class AsyncTakeStream<T> extends AsyncStreamBase<T> {
   }
 
   take(amount: number): AsyncStream<T> {
-    if (amount === this.amount) return this;
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    if (amount >= this.amount) {
+      return this;
+    }
+
     return this.source.take(amount);
   }
 }
@@ -1300,112 +1636,15 @@ class AsyncDropStream<T> extends AsyncStreamBase<T> {
   }
 
   drop(amount: number): AsyncStream<T> {
-    if (amount <= 0) return this;
+    if (amount <= 0) {
+      return this;
+    }
+
     return this.source.drop(this.amount + amount);
   }
 }
 
-class AsyncSplitWhereStream<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly pred: (value: T, index: number) => MaybePromise<boolean>,
-    readonly negate: boolean,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncSplitWhereIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.pred,
-      this.negate,
-      this.collector
-    );
-  }
-}
-
-class AsyncSplitOnStream<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly sepElem: T,
-    readonly eq: Eq<T>,
-    readonly negate: boolean,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncSplitOnIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.sepElem,
-      this.eq,
-      this.negate,
-      this.collector
-    );
-  }
-}
-
-class AsyncSplitOnSeq<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly sepSeq: AsyncStreamSource<T>,
-    readonly eq: Eq<T>,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncSplitOnSeqIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.sepSeq,
-      this.eq,
-      this.collector
-    );
-  }
-}
-
-class AsyncDistinctPreviousStream<T> extends AsyncStreamBase<T> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly eq: Eq<T>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<T> {
-    return new AsyncDistinctPreviousIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.eq,
-      this.negate
-    );
-  }
-}
-
-class AsyncWindowStream<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly windowSize: number,
-    readonly skipAmount: number,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncWindowIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.windowSize,
-      this.skipAmount,
-      this.collector
-    );
-  }
-}
-
-class AsyncReduceStream<I, R> extends AsyncStreamBase<R> {
+class AsyncReduceStream<I, R = I> extends AsyncStreamBase<R> {
   constructor(
     readonly source: AsyncStream<I>,
     readonly reducer: AsyncReducer<I, R>
@@ -1416,7 +1655,23 @@ class AsyncReduceStream<I, R> extends AsyncStreamBase<R> {
   [Symbol.asyncIterator](): AsyncFastIterator<R> {
     return new AsyncReduceIterator<I, R>(
       this.source[Symbol.asyncIterator](),
-      this.reducer.compile()
+      this.reducer
+    );
+  }
+}
+
+export class AsyncTransformerStream<T, R = T> extends AsyncStreamBase<R> {
+  constructor(
+    readonly source: AsyncStream<T>,
+    readonly transformer: AsyncTransformer.Accept<T, R>
+  ) {
+    super();
+  }
+
+  [Symbol.asyncIterator](): AsyncFastIterator<R> {
+    return new AsyncTransformerFastIterator<T, R>(
+      this.source[Symbol.asyncIterator](),
+      this.transformer
     );
   }
 }
@@ -1491,20 +1746,16 @@ class AsyncEmptyStream<T = any>
     return this as any;
   }
   transform<R>(transformer: AsyncTransformer<T, R>): AsyncStream<R> {
-    return AsyncStreamConstructorsImpl.from<R>(
-      async () => await transformer.stateToResult(await transformer.init())
-    );
+    return fromAsyncStreamSource<R>(async () => {
+      const instance = await transformer.compile();
+
+      return instance.getOutput();
+    });
   }
-  filter(): AsyncStream<T> {
+  filter(): any {
     return this;
   }
-  filterNot(): AsyncStream<T> {
-    return this;
-  }
-  filterPure(): AsyncStream<T> {
-    return this;
-  }
-  filterNotPure(): AsyncStream<T> {
+  filterPure(): any {
     return this;
   }
   collect<R>(): AsyncStream<R> {
@@ -1606,9 +1857,7 @@ class AsyncEmptyStream<T = any>
     end = '',
     ifEmpty = undefined,
   } = {}): Promise<string> {
-    if (undefined !== ifEmpty) return ifEmpty;
-
-    return start.concat(end);
+    return undefined !== ifEmpty ? ifEmpty : start.concat(end);
   }
   mkGroup({
     start = emptyAsyncStream as AsyncStreamSource<T>,
@@ -1622,7 +1871,7 @@ class AsyncEmptyStream<T = any>
   splitWhere<R>(): AsyncStream<R> {
     return this as any;
   }
-  splitOnSeq<R>(): AsyncStream<R> {
+  splitOnSlice<R>(): AsyncStream<R> {
     return this as any;
   }
   distinctPrevious(): AsyncStream<T> {
@@ -1639,8 +1888,9 @@ class AsyncEmptyStream<T = any>
   }
   async reduce(shape: any): Promise<any> {
     const reducer = AsyncReducer.combine(shape);
+    const instance = await reducer.compile();
 
-    return reducer.stateToResult(await reducer.init());
+    return instance.getOutput();
   }
   reduceStream(): any {
     return this;
@@ -1835,7 +2085,7 @@ export const AsyncStreamConstructorsImpl: AsyncStreamConstructors =
       );
     },
     flatten(source: any) {
-      return AsyncStreamConstructorsImpl.from(source).flatMap((s: any) => s);
+      return fromAsyncStreamSource(source).flatMap((s: any) => s);
     },
     unzip(source, options) {
       const { length } = options;

--- a/deno_dist/stream/async-custom/async-stream-custom.ts
+++ b/deno_dist/stream/async-custom/async-stream-custom.ts
@@ -34,6 +34,7 @@ import {
   AsyncReduceIterator,
   AsyncRepeatIterator,
   AsyncTakeIterator,
+  AsyncTransformerFastIterator,
   AsyncUnfoldIterator,
   AsyncZipAllWithItererator,
   AsyncZipWithIterator,
@@ -45,7 +46,6 @@ import {
   emptyAsyncFastIterator,
   isAsyncFastIterator,
   type AsyncStreamConstructors,
-  AsyncTransformerFastIterator,
 } from '../../stream/async-custom/index.ts';
 import {
   StreamConstructorsImpl,
@@ -522,7 +522,7 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
 
   async containsSlice(
     source: AsyncStreamSource.NonEmpty<T>,
-    options: { eq?: Eq<T>; negate?: boolean } = {}
+    options: { eq?: Eq<T>; amount?: number } = {}
   ): Promise<boolean> {
     return (this as AsyncStream<T>).reduce(
       AsyncReducer.containsSlice(source, options)
@@ -965,22 +965,6 @@ class AsyncPrependStream<T> extends AsyncStreamBase<T> {
     return compare(result, itemValue) > 0 ? result : itemValue;
   }
 
-  async join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): Promise<string> {
-    return this.source.join({
-      sep,
-      start: `${start}${valueToString(
-        await AsyncOptLazy.toMaybePromise(this.item)
-      )}`,
-      end,
-      valueToString,
-    });
-  }
-
   async toArray(): Promise<T[]> {
     const result = await this.source.toArray();
     result.unshift(await AsyncOptLazy.toMaybePromise(this.item));
@@ -1063,22 +1047,6 @@ class AsyncAppendStream<T> extends AsyncStreamBase<T> {
     }
 
     return compare(result, itemValue) > 0 ? result : itemValue;
-  }
-
-  async join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): Promise<string> {
-    return this.source.join({
-      sep,
-      start,
-      end: `${valueToString(
-        await AsyncOptLazy.toMaybePromise(this.item)
-      )}${end}`,
-      valueToString,
-    });
   }
 
   async toArray(): Promise<T[]> {

--- a/deno_dist/stream/async/async-fast-iterator.ts
+++ b/deno_dist/stream/async/async-fast-iterator.ts
@@ -1,7 +1,24 @@
 import type { AsyncOptLazy, MaybePromise } from '../../common/mod.ts';
 
+/**
+ * An asynchronous iterator that extends the default `AsyncIterator` interface with methods for improved performance.
+ * @typeparam T - the element type
+ */
 export interface AsyncFastIterator<T> extends AsyncIterator<T> {
+  /**
+   * Returns the next iterator value asynchronously, or the given `otherwise` `AsyncOptLazy` value instead.
+   */
   fastNext(): MaybePromise<T | undefined>;
+
+  /**
+   * Returns the next iterator value asynchronously, or the given `otherwise` `AsyncOptLazy` value instead.
+   * @param otherwise - (default: undefined) the value to return if the iterator has no more values
+   * @typeparam O - the type of the alternative value
+   */
   fastNext<O>(otherwise: AsyncOptLazy<O>): MaybePromise<T | O>;
+
+  /**
+   * Returns a promise resolving to the next `IteratorResult`.
+   */
   next(): Promise<IteratorResult<T>>;
 }

--- a/deno_dist/stream/async/async-reducer.ts
+++ b/deno_dist/stream/async/async-reducer.ts
@@ -1,13 +1,22 @@
+import { RimbuError } from '../../base/mod.ts';
 import {
   AsyncOptLazy,
+  CollectFun,
+  Eq,
+  ErrBase,
   type AsyncCollectFun,
   type MaybePromise,
-  CollectFun,
-  type Eq,
-  ErrBase,
 } from '../../common/mod.ts';
-import { Stream, type AsyncStreamSource, type Reducer } from '../../stream/mod.ts';
-import { fromAsyncStreamSource } from '../async-custom/async-stream-custom.ts';
+import {
+  Reducer,
+  Stream,
+  type AsyncFastIterator,
+  type AsyncStreamSource,
+} from '../../stream/mod.ts';
+import {
+  AsyncStreamConstructorsImpl,
+  fromAsyncStreamSource,
+} from '../async-custom/async-stream-custom.ts';
 
 /**
  * An `AsyncReducer` is a stand-alone asynchronous calculation that takes input values of type I,
@@ -22,29 +31,45 @@ function identity<T>(value: T): T {
 }
 
 function combineArr<T, R extends readonly [unknown, unknown, ...unknown[]]>(
-  ...reducers: { [K in keyof R]: AsyncReducer<T, R[K]> } & AsyncReducer<
+  ...reducers: { [K in keyof R]: AsyncReducer.Accept<T, R[K]> } & AsyncReducer<
     T,
     unknown
   >[]
 ): AsyncReducer<T, R> {
   return AsyncReducer.create<T, any, AsyncReducer.Instance<T, unknown>[]>(
-    () => reducers.map((reducer) => reducer.compile()),
+    async (initHalt) => {
+      let allHalted = true;
+
+      const result = await Promise.all(
+        reducers.map(async (reducer) => {
+          const instance = await AsyncReducer.from(reducer).compile();
+
+          allHalted = allHalted && instance.halted;
+
+          return instance;
+        })
+      );
+
+      if (allHalted) {
+        initHalt();
+      }
+
+      return result;
+    },
     async (state, elem, index, halt) => {
-      let anyNotHalted = false;
+      let allHalted = true;
 
       await Promise.all(
-        Stream.from(state).map(async (reducer) => {
+        Stream.from(state).mapPure(async (reducer) => {
           if (reducer.halted) return;
 
           await reducer.next(elem);
 
-          if (!reducer.halted) {
-            anyNotHalted = true;
-          }
+          allHalted = allHalted && reducer.halted;
         })
       );
 
-      if (!anyNotHalted) {
+      if (allHalted) {
         halt();
       }
 
@@ -52,45 +77,60 @@ function combineArr<T, R extends readonly [unknown, unknown, ...unknown[]]>(
     },
     (state) =>
       Promise.all(
-        Stream.from(state).map((reducerInstance) => reducerInstance.getOutput())
+        Stream.from(state).mapPure((reducerInstance) =>
+          reducerInstance.getOutput()
+        )
       ),
     async (state, err) => {
       await Promise.all(
-        Stream.from(state).map((reducer) => reducer.onClose(err))
+        Stream.from(state).mapPure((reducer) => reducer.onClose(err))
       );
     }
   );
 }
 
 function combineObj<T, R extends { readonly [key: string]: unknown }>(
-  reducerObj: { readonly [K in keyof R]: AsyncReducer<T, R[K]> } & Record<
-    string,
-    AsyncReducer<T, unknown>
-  >
+  reducerObj: {
+    readonly [K in keyof R]: AsyncReducer.Accept<T, R[K]>;
+  } & Record<string, AsyncReducer.Accept<T, unknown>>
 ): AsyncReducer<T, R> {
   return AsyncReducer.create(
-    () => {
+    async (initHalt) => {
       const result: Record<string, AsyncReducer.Instance<T, any>> = {};
 
-      for (const key in reducerObj) {
-        result[key] = reducerObj[key].compile();
+      let allHalted = true;
+
+      await Promise.all(
+        Stream.fromObject(
+          reducerObj as Record<string, AsyncReducer.Accept<T, unknown>>
+        ).mapPure(async ([key, reducer]) => {
+          const instance = await AsyncReducer.from(reducer).compile();
+          result[key] = instance;
+
+          allHalted = allHalted && instance.halted;
+        })
+      );
+
+      if (allHalted) {
+        initHalt();
       }
 
       return result;
     },
     async (state, elem, index, halt) => {
-      let anyNotHalted = false;
+      let allHalted = true;
 
       await Promise.all(
-        Stream.fromObjectValues(state).map(async (reducerInstance) => {
+        Stream.fromObjectValues(state).mapPure(async (reducerInstance) => {
           if (!reducerInstance.halted) {
             await reducerInstance.next(elem);
-            anyNotHalted = anyNotHalted || !reducerInstance.halted;
+
+            allHalted = allHalted && reducerInstance.halted;
           }
         })
       );
 
-      if (!anyNotHalted) {
+      if (allHalted) {
         halt();
       }
 
@@ -100,7 +140,7 @@ function combineObj<T, R extends { readonly [key: string]: unknown }>(
       const result: any = {};
 
       await Promise.all(
-        Stream.fromObject(state).map(async ([key, reducerInstance]) => {
+        Stream.fromObject(state).mapPure(async ([key, reducerInstance]) => {
           result[key] = await reducerInstance.getOutput();
         })
       );
@@ -109,7 +149,7 @@ function combineObj<T, R extends { readonly [key: string]: unknown }>(
     },
     async (state, err) => {
       await Promise.all(
-        Stream.fromObjectValues(state).map((reducerInstance) =>
+        Stream.fromObjectValues(state).mapPure((reducerInstance) =>
           reducerInstance.onClose(err)
         )
       );
@@ -118,11 +158,13 @@ function combineObj<T, R extends { readonly [key: string]: unknown }>(
 }
 
 export namespace AsyncReducer {
+  export type Accept<I, O> = AsyncReducer<I, O> | Reducer<I, O>;
+
   export interface Impl<I, O, S> {
     /**
      * The initial state value for the reducer algorithm.
      */
-    readonly init: () => MaybePromise<S>;
+    readonly init: (initHalt: () => void) => MaybePromise<S>;
     /**
      * Returns the next state based on the given input values
      * @param state - the current state
@@ -135,7 +177,7 @@ export namespace AsyncReducer {
      * Returns the output value based on the given `state`
      * @param state - the current state
      */
-    stateToResult(state: S): MaybePromise<O>;
+    stateToResult(state: S, index: number, halted: boolean): MaybePromise<O>;
     /**
      * An optional function that is called when the reducer will no longer receive values.
      * @param state - the final reducer state
@@ -156,8 +198,21 @@ export namespace AsyncReducer {
      * // this reducer will only sum values larger than 10
      * ```
      */
+    filterInput<IF extends I>(
+      pred: (value: I, index: number, halt: () => void) => value is IF,
+      options?: { negate?: false | undefined }
+    ): AsyncReducer<IF, O>;
+    filterInput<IF extends I>(
+      pred: (value: I, index: number, halt: () => void) => value is IF,
+      options: { negate: true }
+    ): AsyncReducer<Exclude<I, IF>, O>;
     filterInput(
-      pred: (value: I, index: number, halt: () => void) => MaybePromise<boolean>
+      pred: (
+        value: I,
+        index: number,
+        halt: () => void
+      ) => MaybePromise<boolean>,
+      options?: { negate?: boolean | undefined }
     ): AsyncReducer<I, O>;
     /**
      * Returns an `AsyncReducer` instance that converts its input values using given `mapFun` before passing them to the reducer.
@@ -272,6 +327,11 @@ export namespace AsyncReducer {
      * ```
      */
     sliceInput(from?: number, amount?: number): AsyncReducer<I, O>;
+    takeOutput(amount: number): AsyncReducer<I, O>;
+    takeOutputWhile(
+      pred: (value: O, index: number) => MaybePromise<boolean>,
+      options?: { negate?: boolean }
+    ): AsyncReducer<I, O>;
     /**
      * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
      * by the previous reducer.
@@ -296,28 +356,28 @@ export namespace AsyncReducer {
      * // => 9
      * ```
      */
-    pipe<O1>(nextReducer1: AsyncReducer<O, O1>): AsyncReducer<I, O1>;
+    pipe<O1>(nextReducer1: AsyncReducer.Accept<O, O1>): AsyncReducer<I, O1>;
     pipe<O1, O2>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>
     ): AsyncReducer<I, O2>;
     pipe<O1, O2, O3>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>,
-      nextReducer3: AsyncReducer<O2, O3>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>,
+      nextReducer3: AsyncReducer.Accept<O2, O3>
     ): AsyncReducer<I, O3>;
     pipe<O1, O2, O3, O4>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>,
-      nextReducer3: AsyncReducer<O2, O3>,
-      nextReducer4: AsyncReducer<O3, O4>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>,
+      nextReducer3: AsyncReducer.Accept<O2, O3>,
+      nextReducer4: AsyncReducer.Accept<O3, O4>
     ): AsyncReducer<I, O4>;
     pipe<O1, O2, O3, O4, O5>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>,
-      nextReducer3: AsyncReducer<O2, O3>,
-      nextReducer4: AsyncReducer<O3, O4>,
-      nextReducer5: AsyncReducer<O4, O5>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>,
+      nextReducer3: AsyncReducer.Accept<O2, O3>,
+      nextReducer4: AsyncReducer.Accept<O3, O4>,
+      nextReducer5: AsyncReducer.Accept<O4, O5>
     ): AsyncReducer<I, O5>;
     /**
      * Returns a reducer that applies the given `nextReducers` sequentially after this reducer
@@ -339,29 +399,29 @@ export namespace AsyncReducer {
      * ```
      */
     chain<O1>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>
     ): AsyncReducer<I, O1>;
     chain<O1, O2>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>
     ): AsyncReducer<I, O2>;
     chain<O1, O2, O3>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>,
-      nextReducer3: AsyncOptLazy<AsyncReducer<I, O3>, [O2]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
+      nextReducer3: AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>
     ): AsyncReducer<I, O3>;
     chain<O1, O2, O3, O4>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>,
-      nextReducer3: AsyncOptLazy<AsyncReducer<I, O3>, [O2]>,
-      nextReducer4: AsyncOptLazy<AsyncReducer<I, O4>, [O3]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
+      nextReducer3: AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
+      nextReducer4: AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>
     ): AsyncReducer<I, O4>;
     chain<O1, O2, O3, O4, O5>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>,
-      nextReducer3: AsyncOptLazy<AsyncReducer<I, O3>, [O2]>,
-      nextReducer4: AsyncOptLazy<AsyncReducer<I, O4>, [O3]>,
-      nextReducer5: AsyncOptLazy<AsyncReducer<I, O5>, [O4]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
+      nextReducer3: AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
+      nextReducer4: AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>,
+      nextReducer5: AsyncOptLazy<AsyncReducer.Accept<I, O5>, [O4]>
     ): AsyncReducer<I, O5>;
     /**
      * Returns a 'runnable' instance of the current reducer specification. This instance maintains its own state
@@ -377,7 +437,7 @@ export namespace AsyncReducer {
      * // => 16
      * ```
      */
-    compile(): AsyncReducer.Instance<I, O>;
+    compile(): Promise<AsyncReducer.Instance<I, O>>;
   }
 
   /**
@@ -388,14 +448,18 @@ export namespace AsyncReducer {
    */
   export class Base<I, O, S> implements AsyncReducer.Impl<I, O, S> {
     constructor(
-      readonly init: () => MaybePromise<S>,
+      readonly init: (initHalt: () => void) => MaybePromise<S>,
       readonly next: (
         state: S,
         elem: I,
         index: number,
         halt: () => void
       ) => MaybePromise<S>,
-      readonly stateToResult: (state: S) => MaybePromise<O>,
+      readonly stateToResult: (
+        state: S,
+        index: number,
+        halted: boolean
+      ) => MaybePromise<O>,
       readonly onClose?: (state: S, error?: unknown) => MaybePromise<void>
     ) {}
 
@@ -405,11 +469,11 @@ export namespace AsyncReducer {
         index: number,
         halt: () => void
       ) => MaybePromise<boolean>,
-      options: { negate?: boolean } = {}
-    ): AsyncReducer<I, O> {
+      options: { negate?: boolean | undefined } = {}
+    ): any {
       const { negate = false } = options;
 
-      return create(
+      return create<I, any>(
         () => this.compile(),
         async (state, elem, index, halt) => {
           if ((await pred(elem, index, halt)) !== negate) {
@@ -499,7 +563,58 @@ export namespace AsyncReducer {
       return create(
         this.init,
         this.next,
-        async (state): Promise<O2> => mapFun(await this.stateToResult(state)),
+        async (state, index, halted): Promise<O2> =>
+          mapFun(await this.stateToResult(state, index, halted)),
+        this.onClose
+      );
+    }
+
+    takeOutput(amount: number): AsyncReducer<I, O> {
+      if (amount <= 0) {
+        return create(
+          (initHalt) => {
+            initHalt();
+            return this.init(initHalt);
+          },
+          this.next,
+          this.stateToResult,
+          this.onClose
+        );
+      }
+
+      return create(
+        this.init,
+        (state, next, index, halt) => {
+          if (index >= amount) {
+            halt();
+          }
+          return this.next(state, next, index, halt);
+        },
+        this.stateToResult,
+        this.onClose
+      );
+    }
+
+    takeOutputWhile(
+      pred: (value: O, index: number) => MaybePromise<boolean>,
+      options: { negate?: boolean } = {}
+    ): AsyncReducer<I, O> {
+      const { negate = false } = options;
+
+      return create(
+        this.init,
+        async (state, next, index, halt) => {
+          const nextState = await this.next(state, next, index, halt);
+
+          const nextOutput = await this.stateToResult(nextState, index, false);
+
+          if ((await pred(nextOutput, index)) === negate) {
+            halt();
+          }
+
+          return state;
+        },
+        this.stateToResult,
         this.onClose
       );
     }
@@ -534,22 +649,36 @@ export namespace AsyncReducer {
       return this.takeInput(amount).dropInput(from);
     }
 
-    pipe<O2>(...nextReducers: AsyncReducer<O, O2>[]): AsyncReducer<I, O2> {
+    pipe<O2>(
+      ...nextReducers: AsyncReducer.Accept<O, O2>[]
+    ): AsyncReducer<I, O2> {
       if (nextReducers.length <= 0) {
         return this as any;
       }
 
-      const [nextReducer, ...others] = nextReducers as AsyncReducer<any, any>[];
+      const [nextReducer, ...others] = nextReducers as AsyncReducer.Accept<
+        any,
+        any
+      >[];
 
       if (others.length > 0) {
         return (this.pipe(nextReducer).pipe as any)(...others);
       }
 
       return AsyncReducer.create(
-        () => ({
-          thisInstance: this.compile(),
-          nextInstance: nextReducer.compile(),
-        }),
+        async (inithalt) => {
+          const thisInstance = await this.compile();
+          const nextInstance = await AsyncReducer.from(nextReducer).compile();
+
+          if (thisInstance.halted || nextInstance.halted) {
+            inithalt();
+          }
+
+          return {
+            thisInstance,
+            nextInstance,
+          };
+        },
         async (state, next, index, halt) => {
           const { thisInstance, nextInstance } = state;
 
@@ -562,7 +691,13 @@ export namespace AsyncReducer {
 
           return state;
         },
-        (state) => state.nextInstance.getOutput(),
+        async (state, index, halted) => {
+          if (halted && index === 0) {
+            await state.nextInstance.next(await state.thisInstance.getOutput());
+          }
+
+          return state.nextInstance.getOutput();
+        },
         async (state, err) => {
           await Promise.all([
             state.thisInstance.onClose(err),
@@ -573,12 +708,12 @@ export namespace AsyncReducer {
     }
 
     chain(
-      ...nextReducers: AsyncOptLazy<AsyncReducer<I, any>, [any]>[]
+      ...nextReducers: AsyncOptLazy<AsyncReducer.Accept<I, any>, [any]>[]
     ): AsyncReducer<I, O> {
       return AsyncReducer.create(
-        () => ({
+        async () => ({
           activeIndex: -1,
-          activeInstance: this.compile() as AsyncReducer.Instance<I, O>,
+          activeInstance: (await this.compile()) as AsyncReducer.Instance<I, O>,
         }),
         async (state, next, index, halt) => {
           while (state.activeInstance.halted) {
@@ -590,7 +725,9 @@ export namespace AsyncReducer {
               nextReducers[++state.activeIndex],
               await state.activeInstance.getOutput()
             );
-            state.activeInstance = nextReducer.compile();
+            state.activeInstance = await AsyncReducer.from(
+              nextReducer
+            ).compile();
           }
 
           await state.activeInstance.next(next);
@@ -609,14 +746,17 @@ export namespace AsyncReducer {
       );
     }
 
-    compile(): AsyncReducer.Instance<I, O> {
-      return new AsyncReducer.InstanceImpl(this);
+    async compile(): Promise<AsyncReducer.Instance<I, O>> {
+      const instance = new AsyncReducer.InstanceImpl(this);
+      await instance.initialize();
+      return instance;
     }
   }
 
   export interface Instance<I, O> {
     get halted(): boolean;
     get index(): number;
+    halt(): void;
     next(value: I): MaybePromise<void>;
     getOutput(): MaybePromise<O>;
     onClose(err?: unknown): Promise<void>;
@@ -625,26 +765,29 @@ export namespace AsyncReducer {
   export class InstanceImpl<I, O, S> implements AsyncReducer.Instance<I, O> {
     constructor(readonly reducer: AsyncReducer.Impl<I, O, S>) {}
 
-    #initialized = false;
-    #_state: S | undefined;
+    #state: S | undefined;
     #index = 0;
+    #initialized = false;
     #halted = false;
     #closed = false;
 
-    async #getState(): Promise<S> {
-      if (!this.#initialized) {
-        this.#_state = await this.reducer.init();
-        this.#initialized = true;
+    async initialize(): Promise<void> {
+      if (this.#closed) {
+        throw new AsyncReducer.ReducerClosedError();
       }
 
-      return this.#_state as S;
+      this.#state = await this.reducer.init(this.halt);
+      this.#initialized = true;
     }
 
-    set #state(value: S) {
-      this.#_state = value;
-    }
+    halt = (): void => {
+      if (this.#closed) {
+        throw new AsyncReducer.ReducerClosedError();
+      }
+      if (!this.#initialized) {
+        throw new AsyncReducer.ReducerNotInitializedError();
+      }
 
-    #halt = (): void => {
       this.#halted = true;
     };
 
@@ -657,30 +800,40 @@ export namespace AsyncReducer {
     }
 
     next = async (value: I): Promise<void> => {
+      if (!this.#initialized) {
+        throw new AsyncReducer.ReducerNotInitializedError();
+      }
+      if (this.#closed) {
+        throw new AsyncReducer.ReducerClosedError();
+      }
       if (this.#halted) {
         throw new AsyncReducer.ReducerHaltedError();
       }
 
       this.#state = await this.reducer.next(
-        await this.#getState(),
+        this.#state!,
         value,
         this.#index++,
-        this.#halt
+        this.halt
       );
     };
 
     async getOutput(): Promise<O> {
-      return this.reducer.stateToResult(await this.#getState());
+      if (!this.#initialized) {
+        throw new AsyncReducer.ReducerNotInitializedError();
+      }
+
+      return this.reducer.stateToResult(this.#state!, this.index, this.halted);
     }
 
     async onClose(err?: unknown): Promise<void> {
       if (this.#closed) {
-        throw Error('already closed');
+        throw new AsyncReducer.ReducerClosedError();
       }
 
       this.#closed = true;
 
-      await this.reducer.onClose?.(await this.#getState(), err);
+      await this.reducer.onClose?.(this.#state!, err);
     }
   }
 
@@ -699,14 +852,18 @@ export namespace AsyncReducer {
    * @typeparam S - the internal state type
    */
   export function create<I, O = I, S = O>(
-    init: () => MaybePromise<S>,
+    init: (initHalt: () => void) => MaybePromise<S>,
     next: (
       current: S,
       next: I,
       index: number,
       halt: () => void
     ) => MaybePromise<S>,
-    stateToResult: (state: S) => MaybePromise<O>,
+    stateToResult: (
+      state: S,
+      index: number,
+      halted: boolean
+    ) => MaybePromise<O>,
     onClose?: (state: S, error?: unknown) => MaybePromise<void>
   ): AsyncReducer<I, O> {
     return new AsyncReducer.Base(
@@ -732,14 +889,18 @@ export namespace AsyncReducer {
    * @typeparam S - the internal state type
    */
   export function createMono<T>(
-    init: () => MaybePromise<T>,
+    init: (initHalt: () => void) => MaybePromise<T>,
     next: (
       current: T,
       next: T,
       index: number,
       halt: () => void
     ) => MaybePromise<T>,
-    stateToResult?: (state: T) => MaybePromise<T>,
+    stateToResult?: (
+      state: T,
+      index: number,
+      halted: boolean
+    ) => MaybePromise<T>,
     onClose?: (state: T, error?: unknown) => MaybePromise<void>
   ): AsyncReducer<T> {
     return create(init, next, stateToResult ?? identity, onClose);
@@ -760,68 +921,51 @@ export namespace AsyncReducer {
    * @typeparam S - the internal state type
    */
   export function createOutput<I, O = I>(
-    init: () => MaybePromise<O>,
+    init: (initHalt: () => void) => MaybePromise<O>,
     next: (
       current: O,
       next: I,
       index: number,
       halt: () => void
     ) => MaybePromise<O>,
-    stateToResult?: (state: O) => MaybePromise<O>,
+    stateToResult?: (
+      state: O,
+      index: number,
+      halted: boolean
+    ) => MaybePromise<O>,
     onClose?: (state: O, error?: unknown) => MaybePromise<void>
   ): AsyncReducer<I, O> {
     return create(init, next, stateToResult ?? identity, onClose);
   }
 
-  export function from<I, O>(reducer: Reducer<I, O>): AsyncReducer<I, O> {
-    return AsyncReducer.create(
-      reducer.init,
-      reducer.next,
-      reducer.stateToResult
+  export function fold<T, R>(
+    init: AsyncOptLazy<R>,
+    next: (
+      current: R,
+      value: T,
+      index: number,
+      halt: () => void
+    ) => MaybePromise<R>
+  ): AsyncReducer<T, R> {
+    return AsyncReducer.createOutput(
+      () => AsyncOptLazy.toMaybePromise(init),
+      next
     );
   }
 
-  /**
-   * A `Reducer` that sums all given numeric input values.
-   * @example
-   * ```ts
-   * console.log(Stream.range({ amount: 5 }).reduce(Reducer.sum))
-   * // => 10
-   * ```
-   */
-  export const sum = createMono(
-    () => 0,
-    (state, next): number => state + next
-  );
-
-  /**
-   * A `Reducer` that calculates the product of all given numeric input values.
-   * @example
-   * ```ts
-   * console.log(Stream.range({ start: 1, amount: 5 }).reduce(product))
-   * // => 120
-   * ```
-   */
-  export const product = createMono(
-    () => 1,
-    (state, next, _, halt): number => {
-      if (0 === next) halt();
-      return state * next;
+  export function from<I, O>(
+    reducer: AsyncReducer.Accept<I, O>
+  ): AsyncReducer<I, O> {
+    if (reducer instanceof AsyncReducer.Base) {
+      return reducer;
     }
-  );
 
-  /**
-   * A `Reducer` that calculates the average of all given numberic input values.
-   * @example
-   * ```ts
-   * console.log(Stream.range({ amount: 5 }).reduce(Reducer.average));
-   * // => 2
-   * ```
-   */
-  export const average = createMono(
-    () => 0,
-    (avg, value, index): number => avg + (value - avg) / (index + 1)
-  );
+    return AsyncReducer.create(
+      reducer.init,
+      reducer.next,
+      reducer.stateToResult as any
+    );
+  }
 
   /**
    * Returns a `Reducer` that remembers the minimum value of the inputs using the given `compFun` to compare input values
@@ -848,6 +992,7 @@ export namespace AsyncReducer {
     otherwise?: AsyncOptLazy<O>
   ) => {
     const token = Symbol();
+
     return create<T, T | O, T | typeof token>(
       () => token,
       async (state, next): Promise<T> => {
@@ -943,124 +1088,6 @@ export namespace AsyncReducer {
   };
 
   /**
-   * Returns a `Reducer` that joins the given input values into a string using the given options.
-   * @param options - an object containing:<br/>
-   * - sep: (optional) a seperator string value between values in the output<br/>
-   * - start: (optional) a start string to prepend to the output<br/>
-   * - end: (optional) an end string to append to the output<br/>
-   * @example
-   * ```ts
-   * console.log(Stream.of(1, 2, 3).reduce(Reducer.join({ sep: '-' })))
-   * // => '1-2-3'
-   * ```
-   */
-  export function join<T>({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String as (value: T) => string,
-  } = {}): AsyncReducer<T, string> {
-    return create(
-      () => ({ result: '', curSep: '', curStart: start }),
-      (state, next) => {
-        state.result = state.curStart.concat(
-          state.result,
-          state.curSep,
-          valueToString(next)
-        );
-        state.curSep = sep;
-        state.curStart = '';
-
-        return state;
-      },
-      (state): string => state.result.concat(end)
-    );
-  }
-
-  /**
-   * Returns an `AsyncReducer` that remembers the amount of input items provided.
-   * @param pred - (optional) a predicate that returns false if the item should not be counted given:<br/>
-   * - value: the current input value<br/>
-   * - index: the input value index
-   * @example
-   * ```ts
-   * const stream = AsyncStream.from(Stream.range({ amount: 10 }))
-   * console.log(await stream.reduce(AsyncReducer.count()))
-   * // => 10
-   * console.log(await stream.reduce(AsyncReducer.count(async v => v < 5)))
-   * // => 5
-   * ```
-   */
-  export const count: {
-    (): AsyncReducer<never, number>;
-    <T>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
-    ): AsyncReducer<T, number>;
-  } = (
-    pred?: (value: any, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
-  ): AsyncReducer<never, number> => {
-    if (undefined === pred)
-      return createOutput(
-        () => 0,
-        (_, __, i): number => i + 1
-      );
-
-    const { negate = false } = options;
-
-    return createOutput(
-      () => 0,
-      async (state, next, i): Promise<number> => {
-        if ((await pred(next, i)) !== negate) return state + 1;
-        return state;
-      }
-    );
-  };
-
-  /**
-   * Returns an `AsyncReducer` that remembers the first input value for which the given `pred` function returns true.
-   * @param pred - a function taking an input value and its index, and returning true if the value should be remembered
-   * @param otherwise - (default: undefined) a fallback value to output if no input value yet has satisfied the given predicate
-   * @typeparam T - the input value type
-   * @typeparam O - the fallback value type
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range({ amount: 10 })).reduce(AsyncReducer.firstWhere(async v => v > 5)))
-   * // => 6
-   * ```
-   */
-  export const firstWhere: {
-    <T>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
-    ): AsyncReducer<T, T | undefined>;
-    <T, O>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean; otherwise: AsyncOptLazy<O> }
-    ): AsyncReducer<T, T | O>;
-  } = <T, O>(
-    pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean; otherwise?: AsyncOptLazy<O> } = {}
-  ) => {
-    const token = Symbol();
-    const { negate = false, otherwise } = options;
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
-      async (state, next, i, halt): Promise<T | typeof token> => {
-        if (token === state && (await pred(next, i)) !== negate) {
-          halt();
-          return next;
-        }
-        return state;
-      },
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
-    );
-  };
-
-  /**
    * Returns an `AsyncReducer` that remembers the first input value.
    * @param otherwise - (default: undefined) a fallback value to output if no input value has been provided
    * @typeparam T - the input value type
@@ -1075,56 +1102,14 @@ export namespace AsyncReducer {
     <T>(): AsyncReducer<T, T | undefined>;
     <T, O>(otherwise: AsyncOptLazy<O>): AsyncReducer<T, T | O>;
   } = <T, O>(otherwise?: AsyncOptLazy<O>): AsyncReducer<T, T | O> => {
-    const token = Symbol();
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
+    return create<T, T | O, T | undefined>(
+      () => undefined,
       (state, next, _, halt): T => {
         halt();
-        if (token === state) return next;
-        return state;
+        return next;
       },
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
-    );
-  };
-
-  /**
-   * Returns an `AsyncReducer` that remembers the last input value for which the given `pred` function returns true.
-   * @param pred - a function taking an input value and its index, and returning true if the value should be remembered
-   * @param otherwise - (default: undefined) a fallback value to output if no input value yet has satisfied the given predicate
-   * @typeparam T - the input value type
-   * @typeparam O - the fallback value type
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range({ amount: 10 })).reduce(AsyncReducer.lastWhere(async v => v > 5)))
-   * // => 9
-   * ```
-   */
-  export const lastWhere: {
-    <T>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
-    ): AsyncReducer<T, T | undefined>;
-    <T, O>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options: { negate?: boolean; otherwise: AsyncOptLazy<O> }
-    ): AsyncReducer<T, T | O>;
-  } = <T, O>(
-    pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean; otherwise?: AsyncOptLazy<O> } = {}
-  ) => {
-    const { negate = false, otherwise } = options;
-    const token = Symbol();
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
-      async (state, next, i): Promise<T | typeof token> => {
-        if ((await pred(next, i)) !== negate) return next;
-        return state;
-      },
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
+      (state, index): MaybePromise<T | O> =>
+        index <= 0 ? AsyncOptLazy.toMaybePromise(otherwise!) : state!
     );
   };
 
@@ -1143,144 +1128,92 @@ export namespace AsyncReducer {
     <T>(): AsyncReducer<T, T | undefined>;
     <T, O>(otherwise: AsyncOptLazy<O>): AsyncReducer<T, T | O>;
   } = <T, O>(otherwise?: AsyncOptLazy<O>): AsyncReducer<T, T | O> => {
-    const token = Symbol();
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
+    return create<T, T | O, T | undefined>(
+      () => undefined,
       (_, next): T => next,
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
+      (state, index): MaybePromise<T | O> =>
+        index <= 0 ? AsyncOptLazy.toMaybePromise(otherwise!) : state!
     );
   };
 
-  /**
-   * Returns a `Reducer` that ouputs false as long as no input value satisfies given `pred`, true otherwise.
-   * @typeparam T - the element type
-   * @param pred - a function taking an input value and its index, and returning true if the value satisfies the predicate
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range{ amount: 10 })).reduce(AsyncReducer.some(async v => v > 5))
-   * // => true
-   * ```
-   */
+  export const single: {
+    <T>(): AsyncReducer<T, T | undefined>;
+    <T, O>(otherwise: AsyncOptLazy<O>): AsyncReducer<T, T | O>;
+  } = <T, O>(otherwise?: AsyncOptLazy<O>): AsyncReducer<T, T | O> => {
+    return create<T, T | O, T | undefined>(
+      () => undefined,
+      (state, next, index, halt): T => {
+        if (index > 1) {
+          halt();
+        }
+        return next;
+      },
+      (state, index): MaybePromise<T | O> =>
+        index !== 1 ? AsyncOptLazy.toMaybePromise(otherwise!) : state!
+    );
+  };
+
   export function some<T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: { negate?: boolean } = {}
   ): AsyncReducer<T, boolean> {
-    const { negate = false } = options;
-
-    return createOutput<T, boolean>(
-      () => false,
-      async (state, next, i, halt): Promise<boolean> => {
-        if (state) return state;
-        const satisfies = (await pred(next, i)) !== negate;
-
-        if (satisfies) {
-          halt();
-        }
-
-        return satisfies;
-      }
-    );
+    return nonEmpty.filterInput(pred, options);
   }
 
-  /**
-   * Returns an `AsyncReducer` that ouputs true as long as all input values satisfy the given `pred`, false otherwise.
-   * @typeparam T - the element type
-   * @param pred - a function taking an input value and its index, and returning true if the value satisfies the predicate
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range{ amount: 10 })).reduce(AsyncReducer.every(async v => v < 5))
-   * // => false
-   * ```
-   */
   export function every<T>(
-    pred: (value: T, index: number) => MaybePromise<boolean>,
+    pred: (value: T, index: number) => boolean,
     options: { negate?: boolean } = {}
   ): AsyncReducer<T, boolean> {
     const { negate = false } = options;
 
-    return createOutput<T, boolean>(
-      () => true,
-      async (state, next, i, halt): Promise<boolean> => {
-        if (!state) return state;
-
-        const satisfies = (await pred(next, i)) !== negate;
-
-        if (!satisfies) {
-          halt();
-        }
-
-        return satisfies;
-      }
-    );
+    return isEmpty.filterInput(pred, { negate: !negate });
   }
 
-  /**
-   * Returns an `AsyncReducer` that outputs false as long as the given `elem` has not been encountered in the input values, true otherwise.
-   * @typeparam T - the element type
-   * @param elem - the element to search for
-   * @param eq - (optional) a comparison function that returns true if te two given input values are considered equal
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range({ amount: 10 })).reduce(AsyncReducer.contains(5)))
-   * // => true
-   * ```
-   */
-  export function contains<T>(
-    elem: T,
+  export function equals<T>(
+    other: AsyncStreamSource<T>,
     options: { eq?: Eq<T>; negate?: boolean } = {}
   ): AsyncReducer<T, boolean> {
-    const { eq = Object.is, negate = false } = options;
+    const { eq = Eq.objectIs, negate = false } = options;
 
-    return createOutput<T, boolean>(
-      () => false,
-      (state, next, _, halt): boolean => {
-        if (state) return state;
-        const satisfies = eq(next, elem) !== negate;
+    const sliceStream = fromAsyncStreamSource(other);
+    const done = Symbol();
 
-        if (satisfies) {
+    return AsyncReducer.create<
+      T,
+      boolean,
+      { iter: AsyncFastIterator<T>; nextSeq: T | typeof done; result: boolean }
+    >(
+      async () => {
+        const iter = sliceStream[Symbol.asyncIterator]();
+
+        const nextSeq = await iter.fastNext(done);
+
+        return { iter, nextSeq, result: false };
+      },
+      async (state, next, _, halt) => {
+        if (done === state.nextSeq) {
           halt();
+          state.result = false;
+          return state;
         }
 
-        return satisfies;
-      }
+        if (eq(next, state.nextSeq) === negate) {
+          halt();
+          state.result = false;
+          return state;
+        }
+
+        state.nextSeq = await state.iter.fastNext(done);
+
+        if (done === state.nextSeq) {
+          state.result = true;
+        }
+
+        return state;
+      },
+      (state, index, halted) => !halted && done === state.nextSeq
     );
   }
-
-  /**
-   * Returns an `AsyncReducer` that takes boolean values and outputs true if all input values are true, and false otherwise.
-   * @example
-   * ```ts
-   * await AsyncStream.of(true, false, true)).reduce(AsyncReducer.and))
-   * // => false
-   * ```
-   */
-  export const and = createMono(
-    () => true,
-    (state, next, _, halt): boolean => {
-      if (!state) return state;
-      if (!next) halt();
-      return next;
-    }
-  );
-
-  /**
-   * Returns an `AsyncReducer` that takes boolean values and outputs true if one or more input values are true, and false otherwise.
-   * @example
-   * ```ts
-   * await AsyncStream.of(true, false, true)).reduce(AsyncReducer.or))
-   * // => true
-   * ```
-   */
-  export const or = createMono(
-    () => false,
-    (state, next, _, halt): boolean => {
-      if (state) return state;
-      if (next) halt();
-      return next;
-    }
-  );
 
   /**
    * Returns an `AsyncReducer` that outputs true if no input values are received, false otherwise.
@@ -1290,7 +1223,7 @@ export namespace AsyncReducer {
    * // => false
    * ```
    */
-  export const isEmpty = createOutput<never, boolean>(
+  export const isEmpty = createOutput<any, boolean>(
     () => true,
     (_, __, ___, halt): false => {
       halt();
@@ -1306,7 +1239,7 @@ export namespace AsyncReducer {
    * // => true
    * ```
    */
-  export const nonEmpty = createOutput<never, boolean>(
+  export const nonEmpty = createOutput<any, boolean>(
     () => false,
     (_, __, ___, halt): true => {
       halt();
@@ -1314,117 +1247,293 @@ export namespace AsyncReducer {
     }
   );
 
-  /**
-   * Returns an `AsyncReducer` that collects received input values in an array, and returns a copy of that array as an output value when requested.
-   * @typeparam T - the element type
-   * @example
-   * ```ts
-   * await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.toArray()))
-   * // => [1, 2, 3]
-   * ```
-   */
-  export function toArray<T>(
-    options: { reversed?: boolean } = {}
-  ): AsyncReducer<T, T[]> {
-    const { reversed = false } = options;
+  export function startsWithSlice<T>(
+    slice: AsyncStreamSource<T>,
+    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+  ): AsyncReducer<T, boolean> {
+    const sliceStream = AsyncStreamConstructorsImpl.from(slice);
+    const done = Symbol();
+    const { eq = Eq.objectIs, amount = 1 } = options;
 
-    return create(
-      (): T[] => [],
-      (state, next): T[] => {
-        if (reversed) state.unshift(next);
-        else state.push(next);
+    return AsyncReducer.create<
+      T,
+      boolean,
+      {
+        sliceIter: AsyncFastIterator<T>;
+        sliceValue: T | typeof done;
+        remain: number;
+      }
+    >(
+      async (initHalt) => {
+        const sliceIter = sliceStream[Symbol.asyncIterator]();
+        const sliceValue = await sliceIter.fastNext(done);
+
+        if (done === sliceValue || amount <= 0) {
+          initHalt();
+          return { sliceIter, sliceValue, remain: 0 };
+        }
+
+        return {
+          sliceIter,
+          sliceValue: sliceValue,
+          remain: amount,
+        };
+      },
+      async (state, next, _, halt) => {
+        if (done === state.sliceValue) {
+          RimbuError.throwInvalidStateError();
+        }
+
+        if (eq(next, state.sliceValue)) {
+          state.sliceValue = await state.sliceIter.fastNext(done);
+
+          if (done === state.sliceValue) {
+            state.remain--;
+            if (state.remain <= 0) {
+              halt();
+            } else {
+              state.sliceIter = sliceStream[Symbol.asyncIterator]();
+              state.sliceValue = await state.sliceIter.fastNext(done);
+            }
+          }
+        } else {
+          halt();
+        }
 
         return state;
       },
-      (state): T[] => state.slice()
+      (state) => state.remain <= 0
     );
   }
 
-  /**
-   * Returns a `AsyncReducer` that collects received input tuples into a mutable JS Map, and returns
-   * a copy of that map when output is requested.
-   * @typeparam K - the map key type
-   * @typeparam V - the map value type
-   * @example
-   * ```ts
-   * await AsyncStream.of([1, 'a'], [2, 'b']).reduce(AsyncReducer.toJSMap()))
-   * // Map { 1 => 'a', 2 => 'b' }
-   * ```
-   */
-  export function toJSMap<K, V>(): AsyncReducer<[K, V], Map<K, V>> {
-    return create(
-      (): Map<K, V> => new Map(),
-      (state, next): Map<K, V> => {
-        state.set(next[0], next[1]);
+  export function endsWithSlice<T>(
+    slice: AsyncStreamSource<T>,
+    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+  ): AsyncReducer<T, boolean> {
+    const sliceStream = AsyncStreamConstructorsImpl.from(slice);
+    const done = Symbol();
+
+    const newReducerSpec = AsyncReducer.startsWithSlice(slice, options);
+
+    return AsyncReducer.create<
+      T,
+      boolean,
+      Set<AsyncReducer.Instance<T, boolean>>
+    >(
+      async (initHalt) => {
+        const sliceIter = sliceStream[Symbol.asyncIterator]();
+        const sliceValue = await sliceIter.fastNext(done);
+
+        if (done === sliceValue) {
+          initHalt();
+        }
+
+        return new Set([await newReducerSpec.compile()]);
+      },
+      async (state, nextValue) => {
+        for (const instance of state) {
+          if (instance.halted) {
+            state.delete(instance);
+          } else {
+            instance.next(nextValue);
+          }
+        }
+
+        const newReducerInstance = await newReducerSpec.compile();
+        await newReducerInstance.next(nextValue);
+
+        state.add(newReducerInstance);
+
         return state;
       },
-      (s): Map<K, V> => new Map(s)
+      (state) =>
+        state.size === 0 ||
+        AsyncStreamConstructorsImpl.from(state).some((instance) =>
+          instance.getOutput()
+        )
     );
   }
 
-  /**
-   * Returns an `AsyncReducer` that collects received input values into a mutable JS Set, and returns
-   * a copy of that map when output is requested.
-   * @typeparam T - the element type
-   * @example
-   * ```ts
-   * await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.toJSSet()))
-   * // Set {1, 2, 3}
-   * ```
-   */
-  export function toJSSet<T>(): AsyncReducer<T, Set<T>> {
-    return create(
-      (): Set<T> => new Set<T>(),
-      (state, next): Set<T> => {
-        state.add(next);
-        return state;
-      },
-      (s): Set<T> => new Set(s)
+  export function containsSlice<T>(
+    slice: AsyncStreamSource<T>,
+    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+  ): AsyncReducer<T, boolean> {
+    const { eq, amount = 1 } = options;
+
+    return endsWithSlice(slice, { eq }).pipe(
+      Reducer.contains(true, { amount })
     );
   }
 
-  /**
-   * Returns an `AsyncReducer` that collects 2-tuples containing keys and values into a plain JS object, and
-   * returns a copy of that object when output is requested.
-   * @typeparam K - the result object key type
-   * @typeparam V - the result object value type
-   * @example
-   * ```ts
-   * await AsyncStream.of(['a', 1], ['b', true]).reduce(AsyncReducer.toJSObject()))
-   * // { a: 1, b: true }
-   * ```
-   */
-  export function toJSObject<
-    K extends string | number | symbol,
-    V
-  >(): AsyncReducer<[K, V], Record<K, V>> {
-    return create(
-      () => ({} as Record<K, V>),
-      (state, entry) => {
-        state[entry[0]] = entry[1];
+  export const partition: {
+    <T, T2 extends T, RT, RF = RT>(
+      pred: (value: T, index: number) => value is T2,
+      options: {
+        collectorTrue: AsyncReducer.Accept<T2, RT>;
+        collectorFalse: AsyncReducer.Accept<Exclude<T, T2>, RF>;
+      }
+    ): AsyncReducer<T, [true: RT, false: RF]>;
+    <T, T2 extends T>(
+      pred: (value: T, index: number) => value is T2,
+      options?: {
+        collectorTrue?: undefined;
+        collectorFalse?: undefined;
+      }
+    ): AsyncReducer<T, [true: T2[], false: Exclude<T, T2>[]]>;
+    <T, RT, RF = RT>(
+      pred: (value: T, index: number) => MaybePromise<boolean>,
+      options: {
+        collectorTrue: AsyncReducer.Accept<T, RT>;
+        collectorFalse: AsyncReducer.Accept<T, RF>;
+      }
+    ): AsyncReducer<T, [true: RT, false: RF]>;
+    <T>(
+      pred: (value: T, index: number) => MaybePromise<boolean>,
+      options?: {
+        collectorTrue?: undefined;
+        collectorFalse?: undefined;
+      }
+    ): AsyncReducer<T, [true: T[], false: T[]]>;
+  } = <T, RT, RF = RT>(
+    pred: (value: T, index: number) => MaybePromise<boolean>,
+    options: {
+      collectorTrue?: any;
+      collectorFalse?: any;
+    } = {}
+  ): AsyncReducer<T, [true: RT, false: RF]> => {
+    const {
+      collectorTrue = Reducer.toArray() as AsyncReducer.Accept<T, RT>,
+      collectorFalse = Reducer.toArray() as AsyncReducer.Accept<T, RF>,
+    } = options;
+
+    return AsyncReducer.create(
+      () =>
+        Promise.all([
+          AsyncReducer.from(collectorTrue).compile(),
+          AsyncReducer.from(collectorFalse).compile(),
+        ]),
+      async (state, value, index) => {
+        const instanceIndex = (await pred(value, index)) ? 0 : 1;
+
+        await state[instanceIndex].next(value);
+
         return state;
       },
-      (s) => ({ ...s })
+      (state) =>
+        Promise.all(
+          Stream.from(state).mapPure((v) => v.getOutput())
+        ) as Promise<[RT, RF]>
     );
-  }
+  };
+
+  export const groupBy: {
+    <T, K, R>(
+      valueToKey: (value: T, index: number) => MaybePromise<K>,
+      options: {
+        collector: AsyncReducer.Accept<[K, T], R>;
+      }
+    ): AsyncReducer<T, R>;
+    <T, K>(
+      valueToKey: (value: T, index: number) => MaybePromise<K>,
+      options?: {
+        collector?: undefined;
+      }
+    ): AsyncReducer<T, Map<K, T[]>>;
+  } = <T, K, R>(
+    valueToKey: (value: T, index: number) => MaybePromise<K>,
+    options: {
+      collector?: AsyncReducer.Accept<[K, T], R> | undefined;
+    } = {}
+  ): AsyncReducer<T, R> => {
+    const {
+      collector = Reducer.toJSMultiMap() as AsyncReducer.Accept<[K, T], R>,
+    } = options;
+
+    return AsyncReducer.create(
+      () => AsyncReducer.from(collector).compile(),
+      async (state, value, index) => {
+        const key = await valueToKey(value, index);
+        await state.next([key, value]);
+        return state;
+      },
+      (state) => state.getOutput()
+    );
+  };
+
+  export const combineFirstDone: {
+    <T, R, O>(
+      reducers: AsyncReducer.Accept<T, R>[],
+      otherwise: AsyncOptLazy<O>
+    ): AsyncReducer<T, R | O>;
+    <T, R>(reducers: AsyncReducer.Accept<T, R>[]): AsyncReducer<
+      T,
+      R | undefined
+    >;
+  } = <T, R, O>(
+    reducers: AsyncReducer.Accept<T, R>[],
+    otherwise?: AsyncOptLazy<O>
+  ) => {
+    return AsyncReducer.create<
+      T,
+      R | O,
+      {
+        instances: AsyncReducer.Instance<T, R>[];
+        doneInstance: AsyncReducer.Instance<T, R> | undefined;
+      }
+    >(
+      async (initHalt) => {
+        const instances = await Promise.all(
+          Stream.from(reducers).mapPure((reducer) =>
+            AsyncReducer.from(reducer).compile()
+          )
+        );
+        const doneInstance = instances.find((instance) => instance.halted);
+
+        if (undefined !== doneInstance) {
+          initHalt();
+        }
+
+        return { instances, doneInstance };
+      },
+      async (state, next, _, halt) => {
+        for (const instance of state.instances) {
+          await instance.next(next);
+
+          if (instance.halted) {
+            state.doneInstance = instance;
+            halt();
+            return state;
+          }
+        }
+
+        return state;
+      },
+      (state) =>
+        state.doneInstance === undefined
+          ? AsyncOptLazy.toMaybePromise(otherwise!)
+          : state.doneInstance.getOutput()
+    );
+  };
 
   export type CombineShape<T = unknown> =
-    | AsyncReducer<T, unknown>
-    | CombineShape<T>[]
-    | { [key: string]: CombineShape<T> };
+    | AsyncReducer.Accept<T, unknown>
+    | AsyncReducer.CombineShape<T>[]
+    | { [key: string]: AsyncReducer.CombineShape<T> };
 
-  export type CombineResult<S extends CombineShape> =
-    /* tuple */ S extends readonly CombineShape[]
+  export type CombineResult<S extends AsyncReducer.CombineShape<any>> =
+    /* tuple */ S extends readonly AsyncReducer.CombineShape[]
       ? /* is array? */ 0 extends S['length']
         ? /* no support for arrays */ never
         : /* only tuples */ {
-            [K in keyof S]: S[K] extends CombineShape
-              ? CombineResult<S[K]>
+            [K in keyof S]: S[K] extends AsyncReducer.CombineShape
+              ? AsyncReducer.CombineResult<S[K]>
               : never;
           }
-      : /* plain object */ S extends { [key: string]: CombineShape }
-      ? { [K in keyof S]: CombineResult<S[K]> }
-      : /* simple reducer */ S extends AsyncReducer<unknown, infer R>
+      : /* plain object */ S extends {
+          [key: string]: AsyncReducer.CombineShape;
+        }
+      ? { [K in keyof S]: AsyncReducer.CombineResult<S[K]> }
+      : /* simple reducer */ S extends AsyncReducer.Accept<unknown, infer R>
       ? R
       : never;
 
@@ -1437,6 +1546,18 @@ export namespace AsyncReducer {
   export class ReducerHaltedError extends ErrBase.CustomError {
     constructor() {
       super('A halted reducer cannot receive more values');
+    }
+  }
+
+  export class ReducerClosedError extends ErrBase.CustomError {
+    constructor() {
+      super('A closed async reducer cannot perform more actions');
+    }
+  }
+
+  export class ReducerNotInitializedError extends ErrBase.CustomError {
+    constructor() {
+      super('The async reducer instance was not yet initialized');
     }
   }
 
@@ -1458,10 +1579,13 @@ export namespace AsyncReducer {
     if (shape instanceof AsyncReducer.Base) {
       return shape as any;
     }
+    if (shape instanceof Reducer.Base) {
+      return AsyncReducer.from(shape) as any;
+    }
 
     if (Array.isArray(shape)) {
       return combineArr(
-        ...(shape.map((item) => AsyncReducer.combine(item)) as any)
+        ...(shape.map((item) => AsyncReducer.combine(item as any)) as any)
       ) as any;
     }
 

--- a/deno_dist/stream/async/async-reducer.ts
+++ b/deno_dist/stream/async/async-reducer.ts
@@ -357,7 +357,10 @@ export namespace AsyncReducer {
      * // => 3
      * ```
      */
-    sliceInput(from?: number, amount?: number): AsyncReducer<I, O>;
+    sliceInput(
+      from?: number | undefined,
+      amount?: number | undefined
+    ): AsyncReducer<I, O>;
     /**
      * Returns an 'AsyncReducer` instance that produces at most `amount` values.
      * @param amount - the maximum amount of values to produce.
@@ -375,7 +378,7 @@ export namespace AsyncReducer {
      */
     takeOutputUntil(
       pred: (value: O, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
+      options?: { negate?: boolean | undefined }
     ): AsyncReducer<I, O>;
     /**
      * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
@@ -1264,7 +1267,7 @@ export namespace AsyncReducer {
    */
   export function some<T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
+    options: { negate?: boolean | undefined } = {}
   ): AsyncReducer<T, boolean> {
     return nonEmpty.filterInput(pred, options);
   }
@@ -1278,7 +1281,7 @@ export namespace AsyncReducer {
    */
   export function every<T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
+    options: { negate?: boolean | undefined } = {}
   ): AsyncReducer<T, boolean> {
     const { negate = false } = options;
 
@@ -1295,7 +1298,7 @@ export namespace AsyncReducer {
    */
   export function equals<T>(
     other: AsyncStreamSource<T>,
-    options: { eq?: Eq<T>; negate?: boolean } = {}
+    options: { eq?: Eq<T> | undefined; negate?: boolean | undefined } = {}
   ): AsyncReducer<T, boolean> {
     const { eq = Eq.objectIs, negate = false } = options;
 
@@ -1504,7 +1507,7 @@ export namespace AsyncReducer {
    */
   export function containsSlice<T>(
     slice: AsyncStreamSource<T>,
-    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+    options: { eq?: Eq<T> | undefined; amount?: number | undefined } = {}
   ): AsyncReducer<T, boolean> {
     const { eq, amount = 1 } = options;
 
@@ -1525,21 +1528,6 @@ export namespace AsyncReducer {
    * @typeparam RT - the reducer result type for the `collectorTrue` value
    * @typeparam RF - the reducer result type for the `collectorFalse` value
    * @note if the predicate is a type guard, the return type is automatically inferred
-   * @example
-   * ```ts
-   * Stream.of(1, 2, 3).partition((v) => v % 2 === 0)
-   * // => [[2], [1, 3]]
-   *
-   * Stream.of<number | string>(1, 'a', 'b', 2)
-   *   .partition((v): v is string => typeof v === 'string')
-   * // => [['a', 'b'], [1, 2]]
-   * // return type is: [string[], number[]]
-   *
-   * Stream.of(1, 2, 3, 4).partition(
-   *   (v) => v % 2 === 0,
-   *   { collectorTrue: Reducer.toJSSet(), collectorFalse: Reducer.sum }
-   * )
-   * // => [Set(2, 4), 4]
    * ```
    */
   export const partition: {
@@ -1613,10 +1601,6 @@ export namespace AsyncReducer {
    * @typeparam T - the input value type
    * @typeparam K - the key type
    * @typeparam R - the collector output type
-   * @example
-   * ```ts
-   * await AsyncStream.of(1, 2, 3).groupBy((v) => v % 2)
-   * // => Map {0 => [2], 1 => [1, 3]}
    * ```
    */
   export const groupBy: {

--- a/deno_dist/stream/async/async-streamable.ts
+++ b/deno_dist/stream/async/async-streamable.ts
@@ -1,11 +1,25 @@
 import type { AsyncStream } from '../../stream/async/index.ts';
 
+/**
+ * Represents an object that can produce an asynchronous stream of values.
+ * @typeparam T - the type of elements in the stream
+ */
 export interface AsyncStreamable<T> {
+  /**
+   * Returns an asynchronous stream of values.
+   */
   asyncStream(): AsyncStream<T>;
 }
 
 export namespace AsyncStreamable {
+  /**
+   * Represents a non-empty object that can produce an asynchronous stream of values.
+   * @typeparam T - the type of elements in the stream
+   */
   export interface NonEmpty<T> {
+    /**
+     * Returns an asynchronous stream of values.
+     */
     asyncStream(): AsyncStream.NonEmpty<T>;
   }
 }

--- a/deno_dist/stream/async/interface.ts
+++ b/deno_dist/stream/async/interface.ts
@@ -636,7 +636,7 @@ export interface AsyncStream<T>
    */
   containsSlice(
     source: AsyncStreamSource.NonEmpty<T>,
-    options?: { eq?: Eq<T> | undefined }
+    options?: { eq?: Eq<T> | undefined; amount?: number }
   ): Promise<boolean>;
   /**
    * Returns an AsyncStream that contains the elements of this stream up to the first element that does not satisfy given `pred` function.

--- a/deno_dist/stream/custom/stream-custom.ts
+++ b/deno_dist/stream/custom/stream-custom.ts
@@ -822,20 +822,6 @@ class PrependStream<T> extends StreamBase<T> {
     return compare(result, itemValue) > 0 ? result : itemValue;
   }
 
-  join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): string {
-    return this.source.join({
-      sep,
-      start: `${start}${valueToString(OptLazy(this.item))}`,
-      end,
-      valueToString,
-    });
-  }
-
   toArray(): T[] {
     const result = this.source.toArray();
     result.unshift(OptLazy(this.item));
@@ -910,20 +896,6 @@ class AppendStream<T> extends StreamBase<T> {
     }
 
     return compare(result, itemValue) > 0 ? result : itemValue;
-  }
-
-  join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): string {
-    return this.source.join({
-      sep,
-      start,
-      end: `${valueToString(OptLazy(this.item))}${end}`,
-      valueToString,
-    });
   }
 
   toArray(): T[] {

--- a/deno_dist/stream/main/interface.ts
+++ b/deno_dist/stream/main/interface.ts
@@ -54,7 +54,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   equals(
     other: StreamSource<T>,
-    options?: { eq?: Eq<T>; negate?: boolean }
+    options?: { eq?: Eq<T> | undefined; negate?: boolean | undefined }
   ): boolean;
   /**
    * Returns the stream as a non-empty instance.
@@ -110,7 +110,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   forEach(
     f: (value: T, index: number, halt: () => void) => void,
-    options?: { state?: TraverseState }
+    options?: { state?: TraverseState | undefined }
   ): void;
   /**
    * Performs given function `f` for each element of the Stream, with the optionally given `args` as extra arguments.
@@ -142,7 +142,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * ```
    * @note O(1)
    */
-  indexed(options?: { startIndex?: number }): Stream<[number, T]>;
+  indexed(options?: { startIndex?: number | undefined }): Stream<[number, T]>;
   /**
    * Returns a Stream where `mapFun` is applied to each element.
    * @typeparam T2 - the resulting element type
@@ -249,10 +249,18 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [2]
    * ```
    */
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options?: { negate?: false | undefined }
+  ): Stream<TF>;
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options: { negate: true }
+  ): Stream<Exclude<T, TF>>;
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
     options?: {
-      negate?: boolean;
+      negate?: boolean | undefined;
     }
   ): Stream<T>;
   /**
@@ -272,10 +280,18 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [1, 3]
    * ```
    */
+  filterPure<A extends readonly unknown[], TF extends T>(options: {
+    pred: (value: T, ...args: A) => value is TF;
+    negate?: false | undefined;
+  }): Stream<TF>;
+  filterPure<A extends readonly unknown[], TF extends T>(options: {
+    pred: (value: T, ...args: A) => value is TF;
+    negate: true;
+  }): Stream<Exclude<T, TF>>;
   filterPure<A extends readonly unknown[]>(
     options: {
       pred: (value: T, ...args: A) => boolean;
-      negate?: boolean;
+      negate?: boolean | undefined;
     },
     ...args: A
   ): Stream<T>;
@@ -365,7 +381,10 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @note O(N) for most types of Stream
    * @note be careful not to use on infinite streams
    */
-  countElement(value: T, options?: { eq?: Eq<T>; negate?: boolean }): number;
+  countElement(
+    value: T,
+    options?: { eq?: Eq<T> | undefined; negate?: boolean | undefined }
+  ): number;
   /**
    * Returns the first element for which the given `pred` function returns true, or a fallback value otherwise.
    * @typeparam O - the optional value type to return if no match is found
@@ -384,13 +403,53 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * ```
    * @note O(N) for most types of Stream
    */
+  find<O, TF extends T>(
+    pred: (value: T, index: number) => value is TF,
+    options: {
+      occurrance?: number | undefined;
+      negate?: false | undefined;
+      otherwise: OptLazy<O>;
+    }
+  ): TF | O;
+  find<O, TF extends T>(
+    pred: (value: T, index: number) => value is TF,
+    options: {
+      occurrance?: number | undefined;
+      negate: true;
+      otherwise: OptLazy<O>;
+    }
+  ): Exclude<T, TF> | O;
+  find<TF extends T>(
+    pred: (value: T, index: number) => value is TF,
+    options?: {
+      occurrance?: number | undefined;
+      negate?: false | undefined;
+      otherwise?: undefined;
+    }
+  ): TF | undefined;
+  find<TF extends T>(
+    pred: (value: T, index: number) => value is TF,
+    options?: {
+      occurrance?: number | undefined;
+      negate: true;
+      otherwise?: undefined;
+    }
+  ): Exclude<T, TF> | undefined;
   find<O>(
     pred: (value: T, index: number) => boolean,
-    options: { occurrance?: number; negate?: boolean; otherwise: OptLazy<O> }
+    options: {
+      occurrance?: number | undefined;
+      negate?: boolean | undefined;
+      otherwise: OptLazy<O>;
+    }
   ): T | O;
   find(
     pred: (value: T, index: number) => boolean,
-    options?: { occurrance?: number; negate?: boolean; otherwise?: undefined }
+    options?: {
+      occurrance?: number | undefined;
+      negate?: boolean | undefined;
+      otherwise?: undefined;
+    }
   ): T | undefined;
   /**
    * Returns the element in the Stream at the given index, or a fallback value (default undefined) otherwise.
@@ -421,7 +480,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   indicesWhere(
     pred: (value: T) => boolean,
-    options?: { negate?: boolean }
+    options?: { negate?: boolean | undefined }
   ): Stream<number>;
   /**
    * Returns a Stream containing the indicies of the occurrance of the given `searchValue`, according to given `eq` function.
@@ -438,7 +497,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   indicesOf(
     searchValue: T,
-    options?: { eq?: Eq<T>; negate?: boolean }
+    options?: { eq?: Eq<T> | undefined; negate?: boolean | undefined }
   ): Stream<number>;
   /**
    * Returns the index of the given `occurrance` instance of the element in the Stream that satisfies given `pred` function,
@@ -456,7 +515,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   indexWhere(
     pred: (value: T, index: number) => boolean,
-    options?: { occurrance?: number; negate?: boolean }
+    options?: { occurrance?: number | undefined; negate?: boolean | undefined }
   ): number | undefined;
   /**
    * Returns the index of the `occurrance` instance of given `searchValue` in the Stream, using given `eq` function,
@@ -478,7 +537,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   indexOf(
     searchValue: T,
-    options?: { occurrance?: number; eq?: Eq<T>; negate?: boolean }
+    options?: {
+      occurrance?: number | undefined;
+      eq?: Eq<T> | undefined;
+      negate?: boolean | undefined;
+    }
   ): number | undefined;
   /**
    * Returns true if any element of the Stream satifies given `pred` function.
@@ -494,7 +557,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   some(
     pred: (value: T, index: number) => boolean,
-    options?: { negate?: boolean }
+    options?: { negate?: boolean | undefined }
   ): boolean;
   /**
    * Returns true if every element of the Stream satifies given `pred` function.
@@ -510,7 +573,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   every(
     pred: (value: T, index: number) => boolean,
-    options?: { negate?: boolean }
+    options?: { negate?: boolean | undefined }
   ): boolean;
   /**
    * Returns true if the Stream contains given `amount` instances of given `value`, using given `eq` function.
@@ -530,7 +593,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   contains(
     value: T,
-    options?: { amount?: number; eq?: Eq<T>; negate?: boolean }
+    options?: {
+      amount?: number | undefined;
+      eq?: Eq<T> | undefined;
+      negate?: boolean | undefined;
+    }
   ): boolean;
   /**
    * Returns true if this stream contains the same sequence of elements as the given `source`,
@@ -548,7 +615,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   containsSlice(
     source: StreamSource.NonEmpty<T>,
-    options?: { eq?: Eq<T> }
+    options?: { eq?: Eq<T> | undefined }
   ): boolean;
   /**
    * Returns a Stream that contains the elements of this Stream up to the first element that does not satisfy given `pred` function.
@@ -564,7 +631,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   takeWhile(
     pred: (value: T, index: number) => boolean,
-    options?: { negate?: boolean }
+    options?: { negate?: boolean | undefined }
   ): Stream<T>;
   /**
    * Returns a Stream that contains the elements of this Stream starting from the first element that does not satisfy given `pred` function.
@@ -580,7 +647,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   dropWhile(
     pred: (value: T, index: number) => boolean,
-    options?: { negate?: boolean }
+    options?: { negate?: boolean | undefined }
   ): Stream<T>;
   /**
    * Returns a stream that contains the elements of this Stream up to a maximum of `amount` elements.
@@ -617,7 +684,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @note amount < 1 will be normalized to amount = 1
    * @note O(1)
    */
-  repeat(amount?: number): Stream<T>;
+  repeat(amount?: number | undefined): Stream<T>;
   /**
    * Returns a Stream containing the elements of this Stream followed by all elements produced by the `others` array of StreamSources.
    * @typeparam T2 - the element type of the stream to concatenate
@@ -744,9 +811,9 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @note O(N)
    */
   mkGroup(options: {
-    sep?: StreamSource<T>;
-    start?: StreamSource<T>;
-    end?: StreamSource<T>;
+    sep?: StreamSource<T> | undefined;
+    start?: StreamSource<T> | undefined;
+    end?: StreamSource<T> | undefined;
   }): Stream<T>;
   /**
    * Returns a Stream of collections of Stream elements, where each collection is filled with elements of this Stream up to the next element that
@@ -763,11 +830,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   splitWhere<R>(
     pred: (value: T, index: number) => boolean,
-    options: { negate?: boolean; collector: Reducer<T, R> }
+    options: { negate?: boolean | undefined; collector: Reducer<T, R> }
   ): Stream<R>;
   splitWhere(
     pred: (value: T, index: number) => boolean,
-    options?: { negate?: boolean; collector?: undefined }
+    options?: { negate?: boolean | undefined; collector?: undefined }
   ): Stream<T[]>;
   /**
    * Returns a Stream of collections of Stream elements, where each collection is filled with elements of this Stream up to the next element that
@@ -785,32 +852,40 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   splitOn<R, T2 extends T = T>(
     sepElem: T2,
-    options: { eq?: Eq<T2>; negate?: boolean; collector: Reducer<T, R> }
+    options: {
+      eq?: Eq<T2> | undefined;
+      negate?: boolean | undefined;
+      collector: Reducer<T, R>;
+    }
   ): Stream<T[]>;
   splitOn(
     sepElem: T,
-    options?: { eq?: Eq<T>; negate?: boolean; collector?: undefined }
+    options?: {
+      eq?: Eq<T> | undefined;
+      negate?: boolean | undefined;
+      collector?: undefined;
+    }
   ): Stream<T[]>;
   /**
    * Returns a Stream of collections of Stream elements, where each collection is filled with elements of this Stream up to the next sequence of elements that
    * equal the given `sepSeq` sequence of elements according to the given `eq` function.
-   * @param sepSeq - a sequence of elements that serves as a separator
+   * @param sepSlice - a sequence of elements that serves as a separator
    * @param options - (optional) object specifying the following properties<br/>
    * - eq: (default: `Eq.objectIs`) the `Eq` instance to use to test equality of elements<br/>
    * - collector: (default: `Reducer.toArray()`) the reducer to use to collect the window values
    * @example
    * ```ts
-   * Stream.from('marmot').splitOnSeq('mo').toArray()  // => [['m', 'a', 'r'], ['t']]
+   * Stream.from('marmot').splitOnSlice('mo').toArray()  // => [['m', 'a', 'r'], ['t']]
    * ```
    * @note O(1)
    */
-  splitOnSeq<R, T2 extends T = T>(
-    sepSeq: StreamSource<T2>,
-    options: { eq?: Eq<T2>; collector: Reducer<T, R> }
+  splitOnSlice<R, T2 extends T = T>(
+    sepSlice: StreamSource<T & T2>,
+    options: { eq?: Eq<T> | undefined; collector: Reducer<T & T2, R> }
   ): Stream<R>;
-  splitOnSeq(
-    sepSeq: StreamSource<T>,
-    options?: { eq?: Eq<T>; collector?: undefined }
+  splitOnSlice<T2 extends T = T>(
+    sepSlice: StreamSource<T & T2>,
+    options?: { eq?: Eq<T> | undefined; collector?: undefined }
   ): Stream<T[]>;
   /**
    * Returns a Stream containing non-repetitive elements of the source stream, where repetitive elements
@@ -824,7 +899,10 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [1, 2, 3, 1]
    * ```
    */
-  distinctPrevious(options?: { eq?: Eq<T>; negate?: boolean }): Stream<T>;
+  distinctPrevious(options?: {
+    eq?: Eq<T> | undefined;
+    negate?: boolean | undefined;
+  }): Stream<T>;
   /**
    * Returns a Stream containing `windows` of `windowSize` consecutive elements of the source stream, with each
    * window starting `skipAmount` elements after the previous one.
@@ -846,14 +924,54 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
   window<R>(
     windowSize: number,
     options: {
-      skipAmount?: number;
+      skipAmount?: number | undefined;
       collector: Reducer<T, R>;
     }
   ): Stream<R>;
   window(
     windowSize: number,
-    options?: { skipAmount?: number; collector?: undefined }
+    options?: { skipAmount?: number | undefined; collector?: undefined }
   ): Stream<T[]>;
+  partition<T2 extends T, RT, RF>(
+    pred: (value: T, index: number) => value is T2,
+    options: {
+      collectorTrue: Reducer<T2, RT>;
+      collectorFalse: Reducer<Exclude<T, T2>, RF>;
+    }
+  ): [true: RT, false: RF];
+  partition<T2 extends T>(
+    pred: (value: T, index: number) => value is T2,
+    options?: {
+      collectorTrue?: undefined;
+      collectorFalse?: undefined;
+    }
+  ): [true: T2[], false: Exclude<T, T2>[]];
+  partition<RT, RF>(
+    pred: (value: T, index: number) => boolean,
+    options: {
+      collectorTrue: Reducer<T, RT>;
+      collectorFalse: Reducer<T, RF>;
+    }
+  ): [true: RT, false: RF];
+  partition(
+    pred: (value: T, index: number) => boolean,
+    options?: {
+      collectorTrue?: undefined;
+      collectorFalse?: undefined;
+    }
+  ): [true: T[], false: T[]];
+  groupBy<K, R>(
+    valueToKey: (value: T, index: number) => K,
+    options: {
+      collector: Reducer<[K, T], R>;
+    }
+  ): R;
+  groupBy<K>(
+    valueToKey: (value: T, index: number) => K,
+    options?: {
+      collector?: undefined;
+    }
+  ): Map<K, T[]>;
   /**
    * Returns the value resulting from applying the given the given `next` function to a current state (initially the given `init` value),
    * and the next Stream value, and returning the new state. When all elements are processed, the resulting state is returned.
@@ -1033,7 +1151,9 @@ export namespace Stream {
      * ```
      * @note O(1)
      */
-    indexed(options?: { startIndex?: number }): Stream.NonEmpty<[number, T]>;
+    indexed(options?: {
+      startIndex?: number | undefined;
+    }): Stream.NonEmpty<[number, T]>;
     /**
      * Returns a non-empty Stream where `mapFun` is applied to each element.
      * @typeparam T2 - the result value type
@@ -1173,7 +1293,7 @@ export namespace Stream {
      * @note amount < 1 will be normalized to amount = 1
      * @note O(1)
      */
-    repeat(amount?: number): Stream.NonEmpty<T>;
+    repeat(amount?: number | undefined): Stream.NonEmpty<T>;
     /**
      * Returns a Stream containing the elements of this Stream followed by all elements produced by the `others` array of StreamSources.
      * @param others - a series of StreamSources to concatenate.
@@ -1251,9 +1371,9 @@ export namespace Stream {
      * @note O(N)
      */
     mkGroup(options: {
-      sep?: StreamSource<T>;
-      start?: StreamSource<T>;
-      end?: StreamSource<T>;
+      sep?: StreamSource<T> | undefined;
+      start?: StreamSource<T> | undefined;
+      end?: StreamSource<T> | undefined;
     }): Stream.NonEmpty<T>;
     /**
      * Returns a non-empty Stream containing non-repetitive elements of the source stream, where repetitive elements
@@ -1268,8 +1388,8 @@ export namespace Stream {
      * ```
      */
     distinctPrevious(options?: {
-      eq?: Eq<T>;
-      negate?: boolean;
+      eq?: Eq<T> | undefined;
+      negate?: boolean | undefined;
     }): Stream.NonEmpty<T>;
     /**
      * Returns a Stream containing the values resulting from applying the given the given `next` function to a current state (initially the given `init` value),

--- a/deno_dist/stream/main/interface.ts
+++ b/deno_dist/stream/main/interface.ts
@@ -615,7 +615,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   containsSlice(
     source: StreamSource.NonEmpty<T>,
-    options?: { eq?: Eq<T> | undefined }
+    options?: { eq?: Eq<T> | undefined; amount?: number | undefined }
   ): boolean;
   /**
    * Returns a Stream that contains the elements of this Stream up to the first element that does not satisfy given `pred` function.

--- a/deno_dist/stream/main/reducer.ts
+++ b/deno_dist/stream/main/reducer.ts
@@ -256,7 +256,7 @@ export namespace Reducer {
      */
     sliceInput(from?: number, amount?: number): Reducer<I, O>;
     takeOutput(amount: number): Reducer<I, O>;
-    takeOutputWhile(
+    takeOutputUntil(
       pred: (value: O, index: number) => boolean,
       options?: { negate?: boolean }
     ): Reducer<I, O>;
@@ -486,7 +486,7 @@ export namespace Reducer {
       return create(
         this.init,
         (state, next, index, halt) => {
-          if (index >= amount) {
+          if (index >= amount - 1) {
             halt();
           }
           return this.next(state, next, index, halt);
@@ -495,7 +495,7 @@ export namespace Reducer {
       );
     }
 
-    takeOutputWhile(
+    takeOutputUntil(
       pred: (value: O, index: number) => boolean,
       options: { negate?: boolean } = {}
     ): Reducer<I, O> {
@@ -508,11 +508,11 @@ export namespace Reducer {
 
           const nextOutput = this.stateToResult(nextState, index, false);
 
-          if (pred(nextOutput, index) === negate) {
+          if (pred(nextOutput, index) !== negate) {
             halt();
           }
 
-          return state;
+          return nextState;
         },
         this.stateToResult
       );
@@ -1459,7 +1459,7 @@ export namespace Reducer {
     );
   };
 
-  export const combineFirstDone: {
+  export const race: {
     <T, R, O>(reducers: Reducer<T, R>[], otherwise: OptLazy<O>): Reducer<
       T,
       R | O

--- a/deno_dist/table/CHANGELOG.md
+++ b/deno_dist/table/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/table@1.1.3...@rimbu/table@2.0.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 ## [1.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/table@1.1.2...@rimbu/table@1.1.3) (2023-12-25)
 
 ### Bug Fixes

--- a/deno_dist/typical/CHANGELOG.md
+++ b/deno_dist/typical/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.8.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/typical@0.7.0...@rimbu/typical@0.8.0) (2024-01-26)
+
+### Features
+
+- major API improvements accross all packages, performance improvements for newer runtimes ([312e473](https://github.com/rimbu-org/rimbu/commit/312e473261696a8e8749399491b9fd29bb5c38ec))
+
+### BREAKING CHANGES
+
+- Many methods now take an options object instead of positional arguments for
+  readability
+
 # [0.7.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/typical@0.6.0...@rimbu/typical@0.7.0) (2023-07-29)
 
 ### Features

--- a/packages/actor/src/main/actor.mts
+++ b/packages/actor/src/main/actor.mts
@@ -1,4 +1,3 @@
-import { OptLazy } from '@rimbu/common';
 import type { Reducer } from '@rimbu/stream';
 
 import type { ActionBase } from './internal.mjs';
@@ -83,14 +82,15 @@ export namespace Actor {
   }): EnhancedActor {
     const { reducer, middleware, enhancer, actions } = config;
 
-    let reducerState = OptLazy(reducer.init);
-
-    let index = 0;
     let halted = false;
 
     const halt = (): void => {
       halted = true;
     };
+
+    let reducerState = reducer.init(halt);
+
+    let index = 0;
 
     const listeners = new Set<Actor.Listener>();
 
@@ -121,7 +121,7 @@ export namespace Actor {
     const actor: any = {
       getState: (): S => {
         if (STALE_STATE === cacheState) {
-          cacheState = reducer.stateToResult(reducerState);
+          cacheState = reducer.stateToResult(reducerState, index, halted);
         }
 
         return cacheState;

--- a/packages/channel/test/examples.test.mts
+++ b/packages/channel/test/examples.test.mts
@@ -1,4 +1,4 @@
-import { AsyncReducer, AsyncStream } from '@rimbu/stream';
+import { AsyncStream, Reducer } from '@rimbu/stream';
 
 import { timeout } from '../src/custom/index.mjs';
 import { Channel, Mutex, WaitGroup } from '../src/main/index.mjs';
@@ -276,7 +276,7 @@ describe('web examples', () => {
 
     console.log(
       'progressive sum',
-      await ch.asyncStream().reduceStream(AsyncReducer.sum).toArray()
+      await ch.asyncStream().reduceStream(Reducer.sum).toArray()
     );
   });
 

--- a/packages/collection-types/src/set-custom/interface/base.mts
+++ b/packages/collection-types/src/set-custom/interface/base.mts
@@ -120,6 +120,7 @@ export interface VariantSetBase<
    * - `halt`: a function that, when called, ensures no next elements are passed
    * @param options - (optional) an object containing the following properties:<br/>
    * - negate: (default: false) when true will negate the predicate
+   * @note if the predicate is a type guard, the return type is automatically inferred
    * @example
    * ```ts
    * HashSet.of(1, 2, 3).filter(value < 3).toArray()

--- a/packages/collection-types/src/set-custom/interface/base.mts
+++ b/packages/collection-types/src/set-custom/interface/base.mts
@@ -126,6 +126,14 @@ export interface VariantSetBase<
    * // => [1, 2]
    * ```
    */
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options?: { negate?: false | undefined }
+  ): WithElem<Tp, TF>['normal'];
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options: { negate: true }
+  ): WithElem<Tp, Exclude<T, TF>>['normal'];
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
     options?: { negate?: boolean }

--- a/packages/hashed/src/set-custom/implementation/immutable.mts
+++ b/packages/hashed/src/set-custom/implementation/immutable.mts
@@ -115,8 +115,8 @@ export abstract class HashSetNonEmptyBase<T>
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { negate?: boolean } = {}
-  ): HashSet<T> {
+    options: { negate?: boolean | undefined } = {}
+  ): any {
     const builder = this.context.builder();
 
     builder.addAll(this.stream().filter(pred, options));

--- a/packages/list/src/custom/implementation/empty.mts
+++ b/packages/list/src/custom/implementation/empty.mts
@@ -85,7 +85,7 @@ export class Empty<T = any> extends EmptyBase implements List<T> {
     return this;
   }
 
-  filter(): this {
+  filter(): any {
     return this;
   }
 

--- a/packages/list/src/custom/implementation/leaf/non-empty.mts
+++ b/packages/list/src/custom/implementation/leaf/non-empty.mts
@@ -195,8 +195,12 @@ export abstract class ListNonEmptyBase<T>
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { range?: IndexRange; reversed?: boolean; negate?: boolean } = {}
-  ): List<T> {
+    options: {
+      range?: IndexRange | undefined;
+      reversed?: boolean | undefined;
+      negate?: boolean | undefined;
+    } = {}
+  ): any {
     const { range, reversed = false, negate = false } = options;
 
     const stream =

--- a/packages/list/src/main/interface.mts
+++ b/packages/list/src/main/interface.mts
@@ -404,6 +404,22 @@ export interface List<T> extends FastIterable<T> {
    *   .filter((_, i) => i > 1, undefined, true)      // -> List(1, 0)
    * ```
    */
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options?: {
+      range?: IndexRange;
+      reversed?: boolean;
+      negate?: false | undefined;
+    }
+  ): List<TF>;
+  filter<TF extends T>(
+    pred: (value: T, index: number, halt: () => void) => value is TF,
+    options: {
+      range?: IndexRange;
+      reversed?: boolean;
+      negate: true;
+    }
+  ): List<Exclude<T, TF>>;
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
     options?: { range?: IndexRange; reversed?: boolean; negate?: boolean }

--- a/packages/list/src/main/interface.mts
+++ b/packages/list/src/main/interface.mts
@@ -393,6 +393,7 @@ export interface List<T> extends FastIterable<T> {
    * @param options - (optional) an object containing the following properties:<br/>
    * - range: (optional) the range of the list to include in the filtering process<br/>
    * - reversed: (default: false) if true reverses the elements within the given range
+   * @note if the predicate is a type guard, the return type is automatically inferred
    * @example
    * ```ts
    * List.of(0, 1, 2, 3).filter(v => v < 2)           // -> List(0, 1)

--- a/packages/multiset/src/custom/implementation/base.mts
+++ b/packages/multiset/src/custom/implementation/base.mts
@@ -342,7 +342,7 @@ export class MultiSetNonEmpty<
 
   filterEntries(
     pred: (entry: readonly [T, number], index: number) => boolean,
-    options: { negate?: boolean } = {}
+    options: { negate?: boolean | undefined } = {}
   ): TpG['normal'] {
     const builder = this.context.builder();
 

--- a/packages/multiset/src/custom/interface/base.mts
+++ b/packages/multiset/src/custom/interface/base.mts
@@ -194,6 +194,7 @@ export interface VariantMultiSetBase<
    * - `halt`: a function that, when called, ensures no next entries are passed
    * @param options - (optional) an object containing the following properties:<br/>
    * - negate: (default: false) when true will negate the predicate
+   * @note if the predicate is a type guard, the return type is automatically inferred
    * @example
    * ```ts
    * HashMultiSet.of(1, 2, 2, 3)

--- a/packages/multiset/src/custom/interface/base.mts
+++ b/packages/multiset/src/custom/interface/base.mts
@@ -202,6 +202,14 @@ export interface VariantMultiSetBase<
    * // => [[2, 2]]
    * ```
    */
+  filterEntries<TF extends T>(
+    pred: (entry: readonly [T, number], index: number) => entry is [TF, number],
+    options?: { negate?: false | undefined }
+  ): WithElem<Tp, TF>['normal'];
+  filterEntries<TF extends T>(
+    pred: (entry: readonly [T, number], index: number) => entry is [TF, number],
+    options: { negate: true }
+  ): WithElem<Tp, Exclude<T, TF>>['normal'];
   filterEntries(
     pred: (entry: readonly [T, number], index: number) => boolean,
     options?: { negate?: boolean }

--- a/packages/ordered/src/set-custom/implementation/non-empty.mts
+++ b/packages/ordered/src/set-custom/implementation/non-empty.mts
@@ -105,13 +105,13 @@ export class OrderedSetNonEmpty<
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { negate?: boolean } = {}
-  ): TpG['normal'] {
+    options: { negate?: boolean | undefined } = {}
+  ): any {
     const builder = this.context.builder<T>();
 
     builder.addAll(this.stream().filter(pred, options));
 
-    if (builder.size === this.size) return this as any;
+    if (builder.size === this.size) return this;
 
     return builder.build();
   }

--- a/packages/sorted/src/set-custom/implementation/immutable.mts
+++ b/packages/sorted/src/set-custom/implementation/immutable.mts
@@ -215,8 +215,8 @@ export abstract class SortedSetNode<T>
 
   filter(
     pred: (value: T, index: number, halt: () => void) => boolean,
-    options: { negate?: boolean } = {}
-  ): SortedSet<T> {
+    options: { negate?: boolean | undefined } = {}
+  ): any {
     const builder = this.context.builder();
 
     builder.addAll(this.stream().filter(pred, options));

--- a/packages/stream/src/async-custom/async-fast-iterator-base.mts
+++ b/packages/stream/src/async-custom/async-fast-iterator-base.mts
@@ -5,11 +5,11 @@ import {
   TraverseState,
   type ArrayNonEmpty,
   type AsyncCollectFun,
-  type Eq,
   type MaybePromise,
 } from '@rimbu/common';
 
 import {
+  AsyncTransformer,
   type AsyncFastIterator,
   type AsyncReducer,
   type AsyncStream,
@@ -84,13 +84,17 @@ export class FromResourceIterator<T, R> extends AsyncFastIteratorBase<T> {
     super();
 
     this.return = async (): Promise<void> => {
-      if (close && this.resource) await close(this.resource);
+      if (close && this.resource) {
+        await close(this.resource);
+        this.resource = undefined;
+      }
       await this.iterator?.return?.();
+      (this.return as any) = undefined;
     };
   }
 
-  resource?: R;
-  iterator?: AsyncFastIterator<T>;
+  resource: R | undefined;
+  iterator: AsyncFastIterator<T> | undefined;
 
   async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<T | O> {
     if (undefined === this.iterator) {
@@ -102,11 +106,20 @@ export class FromResourceIterator<T, R> extends AsyncFastIteratorBase<T> {
         [Symbol.asyncIterator]();
     }
 
-    return this.iterator.fastNext(async () => {
-      await this.return?.();
+    try {
+      return await this.iterator.fastNext(async () => {
+        if (undefined !== this.return) {
+          await this.return();
+        }
 
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    });
+        return AsyncOptLazy.toMaybePromise(otherwise!);
+      });
+    } catch (err) {
+      if (undefined !== this.return) {
+        await this.return();
+      }
+      throw err;
+    }
   }
 }
 
@@ -319,8 +332,12 @@ export class FromPromise<T> extends AsyncFastIteratorBase<T> {
   ) {
     super();
     this.return = async (): Promise<void> => {
-      if (close) await close?.();
-      if (this.iterator) await this.iterator.return?.();
+      if (close) {
+        await close();
+      }
+      if (this.iterator) {
+        await this.iterator.return?.();
+      }
     };
   }
 
@@ -331,10 +348,10 @@ export class FromPromise<T> extends AsyncFastIteratorBase<T> {
       const source = await this.promise();
       this.iterator = this.asyncStreamSourceHelpers
         .fromAsyncStreamSource(source)
-        [Symbol.asyncIterator]() as any;
+        [Symbol.asyncIterator]();
     }
 
-    return this.iterator!.fastNext(otherwise!);
+    return this.iterator.fastNext(otherwise!);
   }
 }
 
@@ -463,70 +480,6 @@ export class AsyncMapPureIterator<
   }
 }
 
-export class AsyncFlatMapIterator<T, T2> extends AsyncFastIteratorBase<T2> {
-  iterator: AsyncFastIterator<T>;
-
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly flatMapFun: (
-      value: T,
-      index: number,
-      halt: () => void
-    ) => AsyncStreamSource<T2>,
-    readonly asyncStreamSourceHelpers: AsyncStreamSourceHelpers
-  ) {
-    super();
-    this.iterator = this.source[Symbol.asyncIterator]();
-    this.return = (): Promise<void> =>
-      closeIters(this.currentIterator, this.iterator);
-  }
-
-  readonly state = TraverseState();
-
-  done = false;
-  currentIterator: null | AsyncFastIterator<T2> = null;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<T2 | O> {
-    const state = this.state;
-
-    if (state.halted || this.done) {
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    const done = Symbol('Done');
-
-    let nextValue: T2 | typeof done;
-
-    const { asyncStreamSourceHelpers } = this;
-
-    while (
-      null === this.currentIterator ||
-      done === (nextValue = await this.currentIterator.fastNext(done))
-    ) {
-      const nextIter = await this.iterator.fastNext(done);
-
-      if (done === nextIter) {
-        this.done = true;
-        return AsyncOptLazy.toMaybePromise(otherwise!);
-      }
-
-      const nextSource = this.flatMapFun(
-        nextIter,
-        state.nextIndex(),
-        state.halt
-      );
-
-      const currentIterator = asyncStreamSourceHelpers
-        .fromAsyncStreamSource(nextSource)
-        [Symbol.asyncIterator]();
-
-      this.currentIterator = currentIterator;
-    }
-
-    return nextValue;
-  }
-}
-
 export class AsyncConcatIterator<T> extends AsyncFastIteratorBase<T> {
   iterator: AsyncFastIterator<T>;
 
@@ -572,70 +525,6 @@ export class AsyncConcatIterator<T> extends AsyncFastIteratorBase<T> {
     }
 
     return value;
-  }
-}
-
-export class AsyncIntersperseIterator<T, S> extends AsyncFastIteratorBase<
-  T | S
-> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly sepStream: AsyncStream<S>
-  ) {
-    super();
-    this.return = async (): Promise<void> => {
-      if (!this.isDone) return closeIters(this.sepIterator, this.source);
-    };
-  }
-
-  sepIterator: AsyncFastIterator<S> | undefined;
-  nextValue!: T;
-  isInitialized = false;
-  isDone = false;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<T | S | O> {
-    if (this.isDone) {
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    const done = Symbol('Done');
-
-    if (undefined !== this.sepIterator) {
-      const sepNext = await this.sepIterator.fastNext(done);
-
-      if (done !== sepNext) return sepNext;
-
-      this.sepIterator = undefined;
-    }
-
-    if (this.isInitialized) {
-      const newNextValue = await this.source.fastNext(done);
-      if (done === newNextValue) {
-        this.isDone = true;
-        return this.nextValue;
-      }
-      const currentNextValue = this.nextValue;
-      this.nextValue = newNextValue;
-      this.sepIterator = this.sepStream[Symbol.asyncIterator]();
-
-      return currentNextValue;
-    }
-
-    const nextValue = await this.source.fastNext(done);
-    if (done === nextValue) {
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    const newNextValue = await this.source.fastNext(done);
-    if (done === newNextValue) {
-      return nextValue;
-    }
-
-    this.nextValue = newNextValue;
-    this.isInitialized = true;
-    this.sepIterator = this.sepStream[Symbol.asyncIterator]();
-
-    return nextValue;
   }
 }
 
@@ -758,102 +647,6 @@ export class AsyncCollectIterator<T, R> extends AsyncFastIteratorBase<R> {
         await closeIters(this);
       }
     }
-  }
-}
-
-export class AsyncIndicesWhereIterator<
-  T
-> extends AsyncFastIteratorBase<number> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly pred: (value: T) => MaybePromise<boolean>,
-    readonly negate: boolean
-  ) {
-    super();
-    this.return = (): Promise<void> => closeIters(source);
-  }
-
-  index = 0;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<number | O> {
-    const done = Symbol('Done');
-    let value: T | typeof done;
-    const source = this.source;
-    const pred = this.pred;
-    const negate = this.negate;
-
-    while (done !== (value = await source.fastNext(done))) {
-      const cond = await pred(value);
-      if (cond !== negate) {
-        return this.index++;
-      }
-      this.index++;
-    }
-
-    return AsyncOptLazy.toMaybePromise(otherwise!);
-  }
-}
-
-export class AsyncIndicesOfIterator<T> extends AsyncFastIteratorBase<number> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly searchValue: T,
-    readonly eq: Eq<T>,
-    readonly negate: boolean
-  ) {
-    super();
-    this.return = (): Promise<void> => closeIters(source);
-  }
-
-  index = 0;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<number | O> {
-    const done = Symbol('Done');
-    let value: T | typeof done;
-    const source = this.source;
-    const searchValue = this.searchValue;
-    const eq = this.eq;
-    const negate = this.negate;
-
-    while (done !== (value = await source.fastNext(done))) {
-      if (eq(searchValue, value) !== negate) return this.index++;
-      this.index++;
-    }
-
-    return AsyncOptLazy.toMaybePromise(otherwise!);
-  }
-}
-
-export class AsyncTakeWhileIterator<T> extends AsyncFastIteratorBase<T> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly pred: (value: T, index: number) => MaybePromise<boolean>,
-    readonly negate: boolean
-  ) {
-    super();
-    this.return = (): Promise<void> => closeIters(source);
-  }
-
-  isDone = false;
-  index = 0;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<T | O> {
-    if (this.isDone) return AsyncOptLazy.toMaybePromise(otherwise!);
-
-    const done = Symbol('Done');
-
-    const next = await this.source.fastNext(done);
-
-    if (done === next) {
-      this.isDone = true;
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    if ((await this.pred(next, this.index++)) === !this.negate) return next;
-
-    this.isDone = true;
-    await closeIters(this);
-    return AsyncOptLazy.toMaybePromise(otherwise!);
   }
 }
 
@@ -987,272 +780,53 @@ export class AsyncRepeatIterator<T> extends AsyncFastIteratorBase<T> {
   }
 }
 
-export class AsyncSplitWhereIterator<T, R> extends AsyncFastIteratorBase<R> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly pred: (value: T, index: number) => MaybePromise<boolean>,
-    readonly negate: boolean,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-    this.return = (): Promise<void> => closeIters(source);
-  }
-
-  index = 0;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<R | O> {
-    const startIndex = this.index;
-
-    if (startIndex < 0) {
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    const collectorInstance = this.collector.compile();
-
-    const source = this.source;
-    const done = Symbol('Done');
-    let value: T | typeof done;
-    const pred = this.pred;
-    const negate = this.negate;
-
-    while (done !== (value = await source.fastNext(done))) {
-      if ((await pred(value, this.index++)) !== negate) {
-        return collectorInstance.getOutput();
-      }
-      await collectorInstance.next(value);
-    }
-
-    (this.return as any) = undefined;
-
-    if (startIndex === this.index) {
-      this.index = -1;
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    this.index = -1;
-    return collectorInstance.getOutput();
-  }
-}
-
-export class AsyncFoldIterator<I, R> extends AsyncFastIteratorBase<R> {
-  constructor(
-    readonly source: AsyncFastIterator<I>,
-    readonly init: AsyncOptLazy<R>,
-    readonly getNext: (
-      current: R,
-      value: I,
-      index: number,
-      halt: () => void
-    ) => MaybePromise<R>
-  ) {
-    super();
-
-    this.return = (): Promise<void> => closeIters(source);
-  }
-
-  current?: R;
-  isInitialized = false;
-
-  state = TraverseState();
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<R | O> {
-    if (!this.isInitialized) {
-      this.current = await AsyncOptLazy.toMaybePromise(this.init);
-      this.isInitialized = true;
-    }
-
-    const state = this.state;
-    if (state.halted) {
-      await closeIters(this);
-
-      (this.return as any) = undefined;
-
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    const done = Symbol('done');
-    const value = await this.source.fastNext(done);
-
-    if (done === value) {
-      (this.return as any) = undefined;
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    this.current = await this.getNext(
-      this.current!,
-      value,
-      state.nextIndex(),
-      state.halt
-    );
-
-    return this.current;
-  }
-}
-
-export class AsyncSplitOnIterator<T, R> extends AsyncFastIteratorBase<R> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly sepElem: T,
-    readonly eq: Eq<T>,
-    readonly negate: boolean,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-    this.return = (): Promise<void> => closeIters(source);
-  }
-
-  isDone = false;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<R | O> {
-    if (this.isDone) {
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    const collectorInstance = this.collector.compile();
-
-    const source = this.source;
-    const done = Symbol('Done');
-    let value: T | typeof done;
-    let processed = false;
-    const eq = this.eq;
-    const sepElem = this.sepElem;
-    const negate = this.negate;
-
-    while (done !== (value = await source.fastNext(done))) {
-      processed = true;
-      if (eq(value, sepElem) !== negate) {
-        return collectorInstance.getOutput();
-      }
-      await collectorInstance.next(value);
-    }
-
-    (this.return as any) = undefined;
-    this.isDone = true;
-
-    if (!processed) {
-      return AsyncOptLazy.toMaybePromise(otherwise!);
-    }
-
-    return collectorInstance.getOutput();
-  }
-}
-
-export class AsyncSplitOnSeqIterator<T, R> extends AsyncFastIteratorBase<R> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly sepSeq: AsyncStreamSource<T>,
-    readonly eq: Eq<T>,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  isDone = false;
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<R | O> {
-    if (this.isDone) {
-      return AsyncOptLazy.toMaybePromise(otherwise) as O;
-    }
-
-    const collectorInstance = this.collector.compile();
-
-    const source = this.source;
-    const done = Symbol('Done');
-
-    const eq = this.eq;
-
-    let processed = false;
-    let buffer: T[] = [];
-    let value: T | typeof done;
-
-    let sepSeqIter = fromAsyncStreamSource(this.sepSeq)[Symbol.asyncIterator]();
-    let seqValue = await sepSeqIter.fastNext(done);
-
-    while (done !== (value = await source.fastNext(done))) {
-      processed = true;
-
-      if (done === seqValue) {
-        await collectorInstance.next(value);
-        return collectorInstance.getOutput();
-      }
-
-      if (eq(value, seqValue)) {
-        buffer.push(value);
-        seqValue = await sepSeqIter.fastNext(done);
-      } else {
-        await fromAsyncStreamSource(buffer).forEachPure(collectorInstance.next);
-        buffer = [];
-
-        sepSeqIter = fromAsyncStreamSource(this.sepSeq)[Symbol.asyncIterator]();
-        seqValue = await sepSeqIter.fastNext(done);
-
-        if (done !== seqValue) {
-          if (eq(value, seqValue)) {
-            seqValue = await sepSeqIter.fastNext(done);
-          } else {
-            await collectorInstance.next(value);
-          }
-        }
-      }
-
-      if (done === seqValue) {
-        return collectorInstance.getOutput();
-      }
-    }
-
-    this.isDone = true;
-
-    if (!processed) {
-      return AsyncOptLazy.toMaybePromise(otherwise) as O;
-    }
-
-    if (done !== seqValue) {
-      await fromAsyncStreamSource(buffer).forEachPure(collectorInstance.next);
-    }
-
-    return collectorInstance.getOutput();
-  }
-}
-
 export class AsyncReduceIterator<I, R> extends AsyncFastIteratorBase<R> {
-  state: unknown;
-
   constructor(
-    readonly source: AsyncFastIterator<I>,
-    readonly reducerInstance: AsyncReducer.Instance<I, R>
+    readonly sourceIterator: AsyncFastIterator<I>,
+    readonly reducer: AsyncReducer<I, R>
   ) {
     super();
 
     this.return = async (): Promise<void> => {
-      await Promise.all([closeIters(source), reducerInstance.onClose()]);
+      if (undefined !== this.#instance && !this.#instance.halted) {
+        await Promise.all([
+          closeIters(sourceIterator),
+          this.#instance.onClose(),
+        ]);
+      } else {
+        await closeIters(sourceIterator);
+      }
     };
   }
 
-  isDone = false;
+  #instance: AsyncReducer.Instance<I, R> | undefined;
 
   async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<R | O> {
-    const reducerInstance = this.reducerInstance;
-
-    if (this.isDone || reducerInstance.halted) {
-      return AsyncOptLazy.toMaybePromise(otherwise!);
+    if (undefined === this.#instance) {
+      this.#instance = await this.reducer.compile();
     }
 
-    const done = Symbol('Done');
-    const value = await this.source.fastNext(done);
+    const reducerInstance = this.#instance;
 
     try {
-      if (done === value) {
-        this.isDone = true;
-        (this.return as any) = undefined;
+      if (reducerInstance.halted) {
+        return (await AsyncOptLazy.toMaybePromise(otherwise)) as O;
+      }
+
+      const done = Symbol('Done');
+      const nextInput = await this.sourceIterator.fastNext(done);
+
+      if (done === nextInput) {
+        this.#instance.halt();
 
         return AsyncOptLazy.toMaybePromise(otherwise!);
       }
 
-      await reducerInstance.next(value);
+      await reducerInstance.next(nextInput);
 
       return reducerInstance.getOutput();
     } finally {
-      if (this.isDone || reducerInstance.halted) {
+      if (reducerInstance.halted) {
         this.return?.();
         (this.return as any) = undefined;
       }
@@ -1260,117 +834,70 @@ export class AsyncReduceIterator<I, R> extends AsyncFastIteratorBase<R> {
   }
 }
 
-export class AsyncDistinctPreviousIterator<T> extends AsyncFastIteratorBase<T> {
+export class AsyncTransformerFastIterator<
+  T,
+  R
+> extends AsyncFastIteratorBase<R> {
   constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly eq: Eq<T>,
-    readonly negate: boolean
+    readonly sourceIterator: AsyncFastIterator<T>,
+    readonly transformer: AsyncTransformer.Accept<T, R>
   ) {
     super();
-    this.return = (): Promise<void> => closeIters(source);
-  }
 
-  readonly previous = [] as T[];
-
-  async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<T | O> {
-    const done = Symbol('Done');
-
-    let next: T | typeof done;
-    const source = this.source;
-    const previous = this.previous;
-    const negate = this.negate;
-
-    while (done !== (next = await source.fastNext(done))) {
-      previous.push(next);
-
-      if (previous.length === 1) {
-        return next;
+    this.return = async (): Promise<void> => {
+      if (undefined !== this.#instance) {
+        await Promise.all([
+          closeIters(sourceIterator),
+          this.#instance.onClose(),
+        ]);
+      } else {
+        await closeIters(sourceIterator);
       }
-
-      const prev = previous.shift()!;
-
-      if (this.eq(prev, next) === negate) {
-        return next;
-      }
-    }
-
-    return AsyncOptLazy.toMaybePromise(otherwise!);
-  }
-}
-
-export class AsyncWindowIterator<T, R> extends AsyncFastIteratorBase<R> {
-  constructor(
-    readonly source: AsyncFastIterator<T>,
-    readonly windowSize: number,
-    readonly skipAmount: number,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-    this.return = (): Promise<void> => closeIters(source);
+    };
   }
 
-  state = new Set<{
-    result: unknown;
-    size: number;
-    halted: boolean;
-    halt: () => void;
-  }>();
-  index = 0;
+  #done = false;
+  #instance: AsyncReducer.Instance<T, AsyncStreamSource<R>> | undefined;
+  #currentValues: AsyncFastIterator<R> | undefined;
 
   async fastNext<O>(otherwise?: AsyncOptLazy<O>): Promise<R | O> {
-    const source = this.source;
-    const collector = this.collector;
-    const windowSize = this.windowSize;
-    const skipAmount = this.skipAmount;
-    const done = Symbol('Done');
-    const state = this.state;
-
-    let next: T | typeof done;
-    let result: R | typeof done = done;
-
-    while (done !== (next = await source.fastNext(done))) {
-      for (const current of state) {
-        current.result = await collector.next(
-          current.result,
-          next,
-          current.size,
-          current.halt
-        );
-        current.size++;
-
-        if (current.size >= windowSize || current.halted) {
-          result = await collector.stateToResult(current.result);
-          state.delete(current);
-        }
-      }
-
-      if (this.index % skipAmount === 0) {
-        const newState = {
-          result: await AsyncOptLazy.toMaybePromise(collector.init),
-          size: 1,
-          halted: false,
-          halt(): void {
-            this.halted = true;
-          },
-        };
-
-        newState.result = await collector.next(
-          AsyncOptLazy.toMaybePromise(collector.init),
-          next,
-          0,
-          newState.halt
-        );
-
-        state.add(newState);
-      }
-
-      this.index++;
-
-      if (done !== result) {
-        return result;
-      }
+    if (this.#done) {
+      return AsyncOptLazy.toPromise(otherwise) as O;
     }
 
-    return AsyncOptLazy.toMaybePromise(otherwise!);
+    if (undefined === this.#instance) {
+      this.#instance = await AsyncTransformer.from(this.transformer).compile();
+    }
+
+    const transformerInstance = this.#instance;
+
+    const done = Symbol('done');
+
+    let nextValue: R | typeof done;
+
+    while (
+      undefined === this.#currentValues ||
+      done === (nextValue = await this.#currentValues.fastNext(done))
+    ) {
+      const nextSource = await this.sourceIterator.fastNext(done);
+
+      if (done === nextSource) {
+        if (transformerInstance.halted) {
+          return AsyncOptLazy.toMaybePromise(otherwise!);
+        }
+
+        this.#done = true;
+        transformerInstance.halt();
+        (this.return as any) = undefined;
+      } else {
+        await transformerInstance.next(nextSource);
+      }
+
+      const nextValuesSource = await transformerInstance.getOutput();
+      this.#currentValues =
+        fromAsyncStreamSource(nextValuesSource)[Symbol.asyncIterator]();
+    }
+
+    return nextValue;
   }
 }

--- a/packages/stream/src/async-custom/async-stream-custom.mts
+++ b/packages/stream/src/async-custom/async-stream-custom.mts
@@ -10,40 +10,31 @@ import {
   type ToJSON,
 } from '@rimbu/common';
 
-import type { StreamSource } from '@rimbu/stream';
-import type {
-  AsyncFastIterator,
-  AsyncStream,
-  AsyncStreamSource,
+import { Transformer, type StreamSource } from '@rimbu/stream';
+import {
+  AsyncReducer,
   AsyncTransformer,
+  type AsyncFastIterator,
+  type AsyncStream,
+  type AsyncStreamSource,
 } from '@rimbu/stream/async';
 import {
   AsyncAppendIterator,
   AsyncCollectIterator,
   AsyncConcatIterator,
-  AsyncDistinctPreviousIterator,
   AsyncDropIterator,
   AsyncDropWhileIterator,
   AsyncFilterIterator,
   AsyncFilterPureIterator,
-  AsyncFlatMapIterator,
-  AsyncFoldIterator,
   AsyncIndexedIterator,
-  AsyncIndicesOfIterator,
-  AsyncIndicesWhereIterator,
-  AsyncIntersperseIterator,
   AsyncMapIterator,
   AsyncMapPureIterator,
   AsyncOfIterator,
   AsyncPrependIterator,
   AsyncReduceIterator,
   AsyncRepeatIterator,
-  AsyncSplitOnIterator,
-  AsyncSplitWhereIterator,
   AsyncTakeIterator,
-  AsyncTakeWhileIterator,
   AsyncUnfoldIterator,
-  AsyncWindowIterator,
   AsyncZipAllWithItererator,
   AsyncZipWithIterator,
   FromAsyncIterator,
@@ -54,13 +45,12 @@ import {
   emptyAsyncFastIterator,
   isAsyncFastIterator,
   type AsyncStreamConstructors,
-  AsyncSplitOnSeqIterator,
+  AsyncTransformerFastIterator,
 } from '@rimbu/stream/async-custom';
 import {
   StreamConstructorsImpl,
   isEmptyStreamSourceInstance,
 } from '@rimbu/stream/custom';
-import { AsyncReducer } from '@rimbu/stream/async';
 
 export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   abstract [Symbol.asyncIterator](): AsyncFastIterator<T>;
@@ -170,6 +160,27 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     return new AsyncIndexedStream<T>(this, startIndex);
   }
 
+  filter(
+    pred: (value: T, index: number, halt: () => void) => MaybePromise<boolean>,
+    options: { negate?: boolean | undefined } = {}
+  ): any {
+    const { negate = false } = options;
+
+    return new AsyncFilterStream<T>(this, pred, negate);
+  }
+
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+
+    return new AsyncFilterPureStream<T, A>(this, pred, args, negate);
+  }
+
   map<T2>(
     mapFun: (value: T, index: number) => MaybePromise<T2>
   ): AsyncStream<T2> {
@@ -183,6 +194,10 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     return new AsyncMapPureStream<T, A, T2>(this, mapFun, args);
   }
 
+  collect<R>(collectFun: AsyncCollectFun<T, R>): AsyncStream<R> {
+    return new AsyncCollectStream<T, R>(this, collectFun);
+  }
+
   flatMap<T2>(
     flatMapFun: (
       value: T,
@@ -190,7 +205,7 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => AsyncStreamSource<T2>
   ): AsyncStream<T2> {
-    return new AsyncFlatMapStream<T, T2>(this, flatMapFun);
+    return this.transform(AsyncTransformer.flatMap(flatMapFun));
   }
 
   flatZip<T2>(
@@ -200,43 +215,11 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => AsyncStreamSource<T2>
   ): AsyncStream<[T, T2]> {
-    return this.flatMap((value, index, halt) =>
-      fromAsyncStreamSource(flatMapFun(value, index, halt)).map((result) => [
-        value,
-        result,
-      ])
-    );
+    return this.transform(AsyncTransformer.flatZip(flatMapFun));
   }
 
-  transform<R>(
-    transformer: AsyncReducer<T, AsyncStreamSource<R>>
-  ): AsyncStream<R> {
-    return AsyncStreamConstructorsImpl.flatten(this.reduceStream(transformer));
-  }
-
-  filter(
-    pred: (value: T, index: number, halt: () => void) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
-  ): AsyncStream<T> {
-    const { negate = false } = options;
-
-    return new AsyncFilterStream<T>(this, pred, negate);
-  }
-
-  filterPure<A extends readonly unknown[]>(
-    options: {
-      pred: (value: T, ...args: A) => MaybePromise<boolean>;
-      negate?: boolean;
-    },
-    ...args: A
-  ): AsyncStream<T> {
-    const { pred, negate = false } = options;
-
-    return new AsyncFilterPureStream<T, A>(this, pred, args, negate);
-  }
-
-  collect<R>(collectFun: AsyncCollectFun<T, R>): AsyncStream<R> {
-    return new AsyncCollectStream<T, R>(this, collectFun);
+  transform<R>(transformer: AsyncTransformer.Accept<T, R>): AsyncStream<R> {
+    return new AsyncTransformerStream(this, transformer);
   }
 
   async first<O>(otherwise?: AsyncOptLazy<O>): Promise<T | O> {
@@ -315,7 +298,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     const iterator = this[Symbol.asyncIterator]();
 
     try {
-      while (done !== (await iterator.fastNext(done))) result++;
+      while (done !== (await iterator.fastNext(done))) {
+        result++;
+      }
 
       return result;
     } catch (err) {
@@ -338,7 +323,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       let current: T | typeof done;
 
       while (done !== (current = await iterator.fastNext(done))) {
-        if (eq(value, current) !== negate) result++;
+        if (eq(value, current) !== negate) {
+          result++;
+        }
       }
 
       return result;
@@ -351,8 +338,8 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   async find<O>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: {
-      occurrance?: number;
-      negate?: boolean;
+      occurrance?: number | undefined;
+      negate?: boolean | undefined;
       otherwise?: AsyncOptLazy<O>;
     } = {}
   ): Promise<T | O> {
@@ -413,18 +400,14 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     pred: (value: T) => MaybePromise<boolean>,
     options: { negate?: boolean } = {}
   ): AsyncStream<number> {
-    const { negate = false } = options;
-
-    return new AsyncIndicesWhereStream<T>(this, pred, negate);
+    return this.transform(AsyncTransformer.indicesWhere(pred, options));
   }
 
   indicesOf(
     searchValue: T,
     options: { eq?: Eq<T>; negate?: boolean } = {}
   ): AsyncStream<number> {
-    const { eq = Eq.objectIs, negate = false } = options;
-
-    return new AsyncIndicesOfStream<T>(this, searchValue, eq, negate);
+    return this.transform(Transformer.indicesOf(searchValue, options));
   }
 
   async indexWhere(
@@ -433,7 +416,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   ): Promise<number | undefined> {
     const { occurrance = 1, negate = false } = options;
 
-    if (occurrance <= 0) return undefined;
+    if (occurrance <= 0) {
+      return undefined;
+    }
 
     const done = Symbol('Done');
     let value: T | typeof done;
@@ -523,7 +508,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   ): Promise<boolean> {
     const { amount = 1 } = options;
 
-    if (amount <= 0) return true;
+    if (amount <= 0) {
+      return true;
+    }
 
     const { eq = Eq.objectIs, negate = false } = options;
 
@@ -537,38 +524,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     source: AsyncStreamSource.NonEmpty<T>,
     options: { eq?: Eq<T>; negate?: boolean } = {}
   ): Promise<boolean> {
-    const { eq = Eq.objectIs, negate = false } = options;
-
-    const iterator = this[Symbol.asyncIterator]();
-    const sourceStream = fromAsyncStreamSource(source);
-    let sourceIterator = sourceStream[Symbol.asyncIterator]();
-
-    const done = Symbol('Done');
-
-    let value: T | typeof done = done;
-
-    try {
-      while (true) {
-        const sourceValue = await sourceIterator.fastNext(done);
-
-        if (done === sourceValue) {
-          return true;
-        }
-
-        value = await iterator.fastNext(done);
-        if (done === value) {
-          return false;
-        }
-
-        if (eq(sourceValue, value) === negate) {
-          sourceIterator = sourceStream[Symbol.asyncIterator]();
-        }
-      }
-    } finally {
-      if (done !== value) {
-        await closeIters(iterator);
-      }
-    }
+    return (this as AsyncStream<T>).reduce(
+      AsyncReducer.containsSlice(source, options)
+    );
   }
 
   takeWhile(
@@ -577,7 +535,15 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   ): AsyncStream<T> {
     const { negate = false } = options;
 
-    return new AsyncTakeWhileStream(this, pred, negate);
+    return this.filter(async (value, index, halt) => {
+      const result = (await pred(value, index)) !== negate;
+
+      if (!result) {
+        halt();
+      }
+
+      return result;
+    });
   }
 
   dropWhile(
@@ -590,13 +556,17 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   }
 
   take(amount: number): AsyncStream<T> {
-    if (amount <= 0) return emptyAsyncStream;
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
 
     return new AsyncTakeStream<T>(this, amount);
   }
 
   drop(amount: number): AsyncStream<T> {
-    if (amount <= 0) return this;
+    if (amount <= 0) {
+      return this;
+    }
 
     return new AsyncDropStream<T>(this, amount);
   }
@@ -679,11 +649,11 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   }
 
   intersperse(sep: AsyncStreamSource<T>): AsyncStream<T> {
-    if (isEmptyAsyncStreamSourceInstance(sep)) return this;
+    if (isEmptyAsyncStreamSourceInstance(sep)) {
+      return this;
+    }
 
-    const sepStream = fromAsyncStreamSource(sep);
-
-    return new AsyncIntersperseStream<T>(this, sepStream);
+    return this.transform(AsyncTransformer.intersperse(sep));
   }
 
   async join({
@@ -729,68 +699,69 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
   splitWhere<R>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: {
-      negate?: boolean;
-      collector?: AsyncReducer<T, R> | undefined;
+      negate?: boolean | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
   ): AsyncStream<R> {
-    const {
-      negate = false,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
-
-    return new AsyncSplitWhereStream<T, R>(this, pred, negate, collector);
+    return this.transform(AsyncTransformer.splitWhere(pred, options));
   }
 
   splitOn<R>(
     sepElem: T,
     options: {
-      eq?: Eq<T>;
-      negate?: boolean;
-      collector?: AsyncReducer<T, R> | undefined;
+      eq?: Eq<T> | undefined;
+      negate?: boolean | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
   ): AsyncStream<R> {
-    const {
-      eq = Eq.objectIs,
-      negate = false,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
-
-    return new AsyncSplitOnStream<T, R>(this, sepElem, eq, negate, collector);
+    return this.transform(AsyncTransformer.splitOn(sepElem, options));
   }
 
-  splitOnSeq<R>(
-    sepSeq: AsyncStreamSource<T>,
-    options: { eq?: Eq<T>; collector?: AsyncReducer<T, R> | undefined } = {}
+  splitOnSlice<R>(
+    sepSlice: AsyncStreamSource<T>,
+    options: {
+      eq?: Eq<T> | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
+    } = {}
   ): AsyncStream<R> {
-    const {
-      eq = Object.is,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
-
-    return new AsyncSplitOnSeq<T, R>(this, sepSeq, eq, collector);
+    return this.transform(AsyncTransformer.splitOnSlice(sepSlice, options));
   }
 
   distinctPrevious(
-    options: { eq?: Eq<T>; negate?: boolean } = {}
+    options: { eq?: Eq<T> | undefined; negate?: boolean | undefined } = {}
   ): AsyncStream<T> {
-    const { eq = Eq.objectIs, negate = false } = options;
-
-    return new AsyncDistinctPreviousStream<T>(this, eq, negate);
+    return this.transform(Transformer.distinctPrevious(options));
   }
 
   window<R>(
     windowSize: number,
     options: {
-      skipAmount?: number;
-      collector?: AsyncReducer<T, R> | undefined;
+      skipAmount?: number | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
   ): AsyncStream<R> {
-    const {
-      skipAmount = windowSize,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
-    } = options;
+    return this.transform(AsyncTransformer.window(windowSize, options as any));
+  }
 
-    return new AsyncWindowStream<T, R>(this, windowSize, skipAmount, collector);
+  partition(
+    pred: (value: T, index: number) => MaybePromise<boolean>,
+    options: {
+      collectorTrue?: any;
+      collectorFalse?: any;
+    } = {}
+  ): Promise<[any, any]> {
+    return (this as AsyncStream<T>).reduce<[any, any]>(
+      AsyncReducer.partition(pred, options)
+    );
+  }
+
+  groupBy<K, R>(
+    valueToKey: (value: T, index: number) => MaybePromise<K>,
+    options: { collector?: AsyncReducer.Accept<[K, T], R> | undefined } = {}
+  ): Promise<R> {
+    return (this as AsyncStream<T>).reduce(
+      AsyncReducer.groupBy<T, K, R>(valueToKey, options as any)
+    );
   }
 
   async fold<R>(
@@ -802,9 +773,7 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => MaybePromise<R>
   ): Promise<R> {
-    return this.reduce(
-      AsyncReducer.createOutput(() => AsyncOptLazy.toMaybePromise(init), next)
-    );
+    return (this as AsyncStream<T>).reduce(AsyncReducer.fold(init, next));
   }
 
   foldStream<R>(
@@ -816,18 +785,15 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
       halt: () => void
     ) => MaybePromise<R>
   ): AsyncStream<R> {
-    return new AsyncFromStream(
-      (): AsyncFastIterator<R> =>
-        new AsyncFoldIterator(this[Symbol.asyncIterator](), init, next)
-    );
+    return (this as AsyncStream<T>).reduceStream(AsyncReducer.fold(init, next));
   }
 
   async reduce<const S extends AsyncReducer.CombineShape<T>>(
     shape: S & AsyncReducer.CombineShape<T>
   ): Promise<AsyncReducer.CombineResult<S>> {
-    const reducerInstance = AsyncReducer.combine(
+    const reducerInstance = (await AsyncReducer.combine<T, S>(
       shape
-    ).compile() as AsyncReducer.Instance<T, AsyncReducer.CombineResult<S>>;
+    ).compile()) as AsyncReducer.Instance<T, AsyncReducer.CombineResult<S>>;
 
     const done = Symbol('Done');
     let value: T | typeof done = done;
@@ -843,18 +809,15 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
 
       return await reducerInstance.getOutput();
     } finally {
+      await closeIters(iter);
       await reducerInstance.onClose();
-
-      if (done !== value) {
-        await closeIters(iter);
-      }
     }
   }
 
   reduceStream<const S extends AsyncReducer.CombineShape<T>>(
     shape: S & AsyncReducer.CombineShape<T>
   ): AsyncStream<AsyncReducer.CombineResult<S>> {
-    const reducer = AsyncReducer.combine(shape) as AsyncReducer<
+    const reducer = AsyncReducer.combine<T, S>(shape) as AsyncReducer<
       T,
       AsyncReducer.CombineResult<S>
     >;
@@ -924,6 +887,105 @@ class AsyncPrependStream<T> extends AsyncStreamBase<T> {
   async count(): Promise<number> {
     return (await this.source.count()) + 1;
   }
+
+  async forEach(
+    f: (value: T, index: number, halt: () => void) => MaybePromise<void>,
+    options: { state?: TraverseState } = {}
+  ): Promise<void> {
+    const { state = TraverseState() } = options;
+
+    if (state.halted) return;
+
+    await f(
+      await AsyncOptLazy.toMaybePromise(this.item),
+      state.nextIndex(),
+      state.halt
+    );
+
+    if (state.halted) return;
+
+    await this.source.forEach(f, { state });
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    return new AsyncPrependStream(
+      this.source.mapPure(mapFun, ...args),
+      async () => mapFun(await AsyncOptLazy.toMaybePromise(this.item), ...args)
+    );
+  }
+
+  take(amount: number): AsyncStream<T> {
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    if (amount === 1) {
+      return AsyncStreamConstructorsImpl.of(this.item);
+    }
+
+    return new AsyncPrependStream(this.source.take(amount - 1), this.item);
+  }
+
+  drop(amount: number): AsyncStream<T> {
+    if (amount <= 0) {
+      return this;
+    }
+
+    if (amount === 1) {
+      return this.source;
+    }
+
+    return this.source.drop(amount - 1);
+  }
+
+  async minBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.minBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) <= 0 ? result : itemValue;
+  }
+
+  async maxBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.maxBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) > 0 ? result : itemValue;
+  }
+
+  async join({
+    sep = '',
+    start = '',
+    end = '',
+    valueToString = String,
+  } = {}): Promise<string> {
+    return this.source.join({
+      sep,
+      start: `${start}${valueToString(
+        await AsyncOptLazy.toMaybePromise(this.item)
+      )}`,
+      end,
+      valueToString,
+    });
+  }
+
+  async toArray(): Promise<T[]> {
+    const result = await this.source.toArray();
+    result.unshift(await AsyncOptLazy.toMaybePromise(this.item));
+    return result;
+  }
 }
 
 class AsyncAppendStream<T> extends AsyncStreamBase<T> {
@@ -942,12 +1004,87 @@ class AsyncAppendStream<T> extends AsyncStreamBase<T> {
     return this.source.first(this.item);
   }
 
-  async last(): Promise<T> {
+  last(): Promise<T> {
     return AsyncOptLazy.toPromise(this.item);
   }
 
   async count(): Promise<number> {
     return (await this.source.count()) + 1;
+  }
+
+  async forEach(
+    f: (value: T, index: number, halt: () => void) => MaybePromise<void>,
+    options: { state?: TraverseState } = {}
+  ): Promise<void> {
+    const { state = TraverseState() } = options;
+
+    if (state.halted) return;
+
+    await this.source.forEach(f, { state });
+
+    if (state.halted) return;
+
+    await f(
+      await AsyncOptLazy.toMaybePromise(this.item),
+      state.nextIndex(),
+      state.halt
+    );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    return new AsyncAppendStream(
+      this.source.mapPure(mapFun, ...args),
+      async () => mapFun(await AsyncOptLazy.toMaybePromise(this.item), ...args)
+    );
+  }
+
+  async minBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.minBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) <= 0 ? result : itemValue;
+  }
+
+  async maxBy<O>(compare: (v1: T, v2: T) => number): Promise<T | O> {
+    const token = Symbol();
+    const result = await this.source.maxBy(compare, token);
+    const itemValue = await AsyncOptLazy.toMaybePromise(this.item);
+
+    if (token === result) {
+      return itemValue;
+    }
+
+    return compare(result, itemValue) > 0 ? result : itemValue;
+  }
+
+  async join({
+    sep = '',
+    start = '',
+    end = '',
+    valueToString = String,
+  } = {}): Promise<string> {
+    return this.source.join({
+      sep,
+      start,
+      end: `${valueToString(
+        await AsyncOptLazy.toMaybePromise(this.item)
+      )}${end}`,
+      valueToString,
+    });
+  }
+
+  async toArray(): Promise<T[]> {
+    const result = await this.source.toArray();
+    result.push(await AsyncOptLazy.toMaybePromise(this.item));
+    return result;
   }
 }
 
@@ -1018,6 +1155,22 @@ class AsyncMapStream<T, T2> extends AsyncStreamBase<T2> {
       mapFun(await this.mapFun(value, index), index)
     );
   }
+
+  take(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    return new AsyncMapStream(this.source.take(amount), this.mapFun);
+  }
+
+  drop(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return this;
+    }
+
+    return new AsyncMapStream(this.source.drop(amount), this.mapFun);
+  }
 }
 
 class AsyncMapPureStream<
@@ -1068,25 +1221,40 @@ class AsyncMapPureStream<
     if (done === value) return AsyncOptLazy.toPromise(otherwise!);
     return this.mapFun(value, ...this.args);
   }
-}
 
-class AsyncFlatMapStream<T, T2> extends AsyncStreamBase<T2> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly flatmapFun: (
-      value: T,
-      index: number,
-      halt: () => void
-    ) => AsyncStreamSource<T2>
-  ) {
-    super();
+  mapPure<T3, A2 extends readonly unknown[]>(
+    mapFun: (value: T2, ...args: A2) => MaybePromise<T3>,
+    ...args: A2
+  ): AsyncStream<T3> {
+    return new AsyncMapPureStream<T, A2, T3>(
+      this.source,
+      async (value, ...args) =>
+        mapFun(await this.mapFun(value, ...this.args), ...args),
+      args
+    );
   }
 
-  [Symbol.asyncIterator](): AsyncFastIterator<T2> {
-    return new AsyncFlatMapIterator<T, T2>(
-      this.source,
-      this.flatmapFun,
-      asyncStreamSourceHelpers
+  take(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    return new AsyncMapPureStream(
+      this.source.take(amount),
+      this.mapFun,
+      this.args
+    );
+  }
+
+  drop(amount: number): AsyncStream<T2> {
+    if (amount <= 0) {
+      return this;
+    }
+
+    return new AsyncMapPureStream(
+      this.source.drop(amount),
+      this.mapFun,
+      this.args
     );
   }
 }
@@ -1094,7 +1262,7 @@ class AsyncFlatMapStream<T, T2> extends AsyncStreamBase<T2> {
 class AsyncConcatStream<T> extends AsyncStreamBase<T> {
   constructor(
     readonly source: AsyncStream<T>,
-    readonly others: AsyncStreamSource<T>[]
+    readonly otherSources: AsyncStreamSource<T>[]
   ) {
     super();
   }
@@ -1102,25 +1270,137 @@ class AsyncConcatStream<T> extends AsyncStreamBase<T> {
   [Symbol.asyncIterator](): AsyncFastIterator<T> {
     return new AsyncConcatIterator(
       this.source,
-      this.others,
+      this.otherSources,
       asyncStreamSourceHelpers
     );
   }
-}
 
-class AsyncIntersperseStream<T> extends AsyncStreamBase<T> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly sepStream: AsyncStream<T>
-  ) {
-    super();
+  async forEach(
+    f: (value: T, index: number, halt: () => void) => MaybePromise<void>,
+    options: { state?: TraverseState } = {}
+  ): Promise<void> {
+    const { state = TraverseState() } = options;
+
+    if (state.halted) return;
+
+    await this.source.forEach(f, { state });
+
+    let sourceIndex = -1;
+    const sources = this.otherSources;
+    const length = sources.length;
+
+    while (!state.halted && ++sourceIndex < length) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        await fromAsyncStreamSource(source).forEach(f, { state });
+      }
+    }
   }
 
-  [Symbol.asyncIterator](): AsyncFastIterator<T> {
-    return new AsyncIntersperseIterator(
-      this.source[Symbol.asyncIterator](),
-      this.sepStream
+  async forEachPure<A extends readonly unknown[]>(
+    f: (value: T, ...args: A) => MaybePromise<void>,
+    ...args: A
+  ): Promise<void> {
+    await this.source.forEachPure(f, ...args);
+
+    let sourceIndex = -1;
+    const sources = this.otherSources;
+    const length = sources.length;
+
+    while (++sourceIndex < length) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        await fromAsyncStreamSource(source).forEachPure(f, ...args);
+      }
+    }
+  }
+
+  async last<O>(otherwise?: AsyncOptLazy<O>): Promise<T | O> {
+    const sources = this.otherSources;
+    let sourceIndex = sources.length;
+
+    while (--sourceIndex >= 0) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        const done = Symbol('Done');
+        const value = await fromAsyncStreamSource(source).last(done);
+        if (done !== value) return value;
+      }
+    }
+
+    return this.source.last(otherwise!);
+  }
+
+  async count(): Promise<number> {
+    let result = await this.source.count();
+
+    const sources = this.otherSources;
+    const length = sources.length;
+    let sourceIndex = -1;
+
+    while (++sourceIndex < length) {
+      const source = sources[sourceIndex];
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        result += await fromAsyncStreamSource(source).count();
+      }
+    }
+
+    return result;
+  }
+
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    return new AsyncConcatStream(
+      this.source.filterPure(options, ...args),
+      this.otherSources.map((source) =>
+        fromAsyncStreamSource(source).filterPure(options, ...args)
+      )
     );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    return new AsyncConcatStream(
+      this.source.mapPure(mapFun, ...args),
+      this.otherSources.map((source) =>
+        fromAsyncStreamSource(source).mapPure(mapFun, ...args)
+      )
+    );
+  }
+
+  concat<T2>(...others2: AsyncStreamSource<T2>[]): any {
+    return new AsyncConcatStream<T | T2>(
+      this.source,
+      (this.otherSources as AsyncStreamSource<T | T2>[]).concat(others2)
+    );
+  }
+
+  async toArray(): Promise<T[]> {
+    let result: T[] = await this.source.toArray();
+
+    let sourceIndex = -1;
+    const sources = this.otherSources;
+    const length = sources.length;
+
+    while (++sourceIndex < length) {
+      const source = sources[sourceIndex];
+
+      if (!isEmptyAsyncStreamSourceInstance(source)) {
+        result = result.concat(await fromAsyncStreamSource(source).toArray());
+      }
+    }
+
+    return result;
   }
 }
 
@@ -1145,13 +1425,36 @@ class AsyncFilterStream<T> extends AsyncStreamBase<T> {
     );
   }
 
-  filter(
-    pred: (value: T, index: number, halt: () => void) => MaybePromise<boolean>
-  ): AsyncStream<T> {
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+    const { pred: thisPred, negate: thisNegate } = this;
+
     return new AsyncFilterStream(
       this.source,
-      async (v, i, halt) =>
-        (await this.pred(v, i, halt)) && (await pred(v, i, halt))
+      async (value, index, halt) =>
+        (await thisPred(value, index, halt)) !== thisNegate &&
+        (await pred(value, ...args)) !== negate
+    );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    const { pred, negate } = this;
+
+    return new AsyncCollectStream(
+      this.source,
+      async (value, index, skip, halt) =>
+        (await pred(value, index, halt)) !== negate
+          ? mapFun(value, ...args)
+          : skip
     );
   }
 }
@@ -1177,6 +1480,44 @@ class AsyncFilterPureStream<
       this.negate
     );
   }
+
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: T, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+
+    const thisPred = this.pred;
+    const thisArgs = this.args;
+    const thisNegate = this.negate;
+
+    return new AsyncFilterPureStream(
+      this.source,
+      async (value, ...args) => {
+        return (
+          (await thisPred(value, ...thisArgs)) !== thisNegate &&
+          (await pred(value, ...args)) !== negate
+        );
+      },
+      args
+    );
+  }
+
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: T, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    const { pred, negate, args: thisArgs } = this;
+
+    return new AsyncCollectStream(this.source, async (value, _, skip) =>
+      (await pred(value, ...thisArgs)) !== negate
+        ? mapFun(value, ...args)
+        : skip
+    );
+  }
 }
 
 class AsyncCollectStream<T, R> extends AsyncStreamBase<R> {
@@ -1193,60 +1534,48 @@ class AsyncCollectStream<T, R> extends AsyncStreamBase<R> {
       this.collectFun
     );
   }
-}
 
-class AsyncIndicesWhereStream<T> extends AsyncStreamBase<number> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly pred: (value: T) => MaybePromise<boolean>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
+  filterPure<A extends readonly unknown[]>(
+    options: {
+      pred: (value: R, ...args: A) => MaybePromise<boolean>;
+      negate?: boolean | undefined;
+    },
+    ...args: A
+  ): any {
+    const { pred, negate = false } = options;
+    const { collectFun } = this;
 
-  [Symbol.asyncIterator](): AsyncFastIterator<number> {
-    return new AsyncIndicesWhereIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.pred,
-      this.negate
+    return new AsyncCollectStream(
+      this.source,
+      async (value, index, skip, halt) => {
+        const result = await collectFun(value, index, skip, halt);
+
+        if (skip === result || (await pred(result, ...args)) === negate) {
+          return skip;
+        }
+
+        return result;
+      }
     );
   }
-}
 
-class AsyncIndicesOfStream<T> extends AsyncStreamBase<number> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly searchValue: T,
-    readonly eq: Eq<T>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
+  mapPure<T2, A extends readonly unknown[]>(
+    mapFun: (value: R, ...args: A) => MaybePromise<T2>,
+    ...args: A
+  ): AsyncStream<T2> {
+    const { collectFun } = this;
 
-  [Symbol.asyncIterator](): AsyncFastIterator<number> {
-    return new AsyncIndicesOfIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.searchValue,
-      this.eq,
-      this.negate
-    );
-  }
-}
+    return new AsyncCollectStream(
+      this.source,
+      async (value, index, skip, halt) => {
+        const result = await collectFun(value, index, skip, halt);
 
-class AsyncTakeWhileStream<T> extends AsyncStreamBase<T> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly pred: (value: T, index: number) => MaybePromise<boolean>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
+        if (skip === result) {
+          return skip;
+        }
 
-  [Symbol.asyncIterator](): AsyncFastIterator<T> {
-    return new AsyncTakeWhileIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.pred,
-      this.negate
+        return mapFun(result, ...args);
+      }
     );
   }
 }
@@ -1282,7 +1611,14 @@ class AsyncTakeStream<T> extends AsyncStreamBase<T> {
   }
 
   take(amount: number): AsyncStream<T> {
-    if (amount === this.amount) return this;
+    if (amount <= 0) {
+      return emptyAsyncStream;
+    }
+
+    if (amount >= this.amount) {
+      return this;
+    }
+
     return this.source.take(amount);
   }
 }
@@ -1300,112 +1636,15 @@ class AsyncDropStream<T> extends AsyncStreamBase<T> {
   }
 
   drop(amount: number): AsyncStream<T> {
-    if (amount <= 0) return this;
+    if (amount <= 0) {
+      return this;
+    }
+
     return this.source.drop(this.amount + amount);
   }
 }
 
-class AsyncSplitWhereStream<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly pred: (value: T, index: number) => MaybePromise<boolean>,
-    readonly negate: boolean,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncSplitWhereIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.pred,
-      this.negate,
-      this.collector
-    );
-  }
-}
-
-class AsyncSplitOnStream<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly sepElem: T,
-    readonly eq: Eq<T>,
-    readonly negate: boolean,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncSplitOnIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.sepElem,
-      this.eq,
-      this.negate,
-      this.collector
-    );
-  }
-}
-
-class AsyncSplitOnSeq<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly sepSeq: AsyncStreamSource<T>,
-    readonly eq: Eq<T>,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncSplitOnSeqIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.sepSeq,
-      this.eq,
-      this.collector
-    );
-  }
-}
-
-class AsyncDistinctPreviousStream<T> extends AsyncStreamBase<T> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly eq: Eq<T>,
-    readonly negate: boolean
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<T> {
-    return new AsyncDistinctPreviousIterator<T>(
-      this.source[Symbol.asyncIterator](),
-      this.eq,
-      this.negate
-    );
-  }
-}
-
-class AsyncWindowStream<T, R> extends AsyncStreamBase<R> {
-  constructor(
-    readonly source: AsyncStream<T>,
-    readonly windowSize: number,
-    readonly skipAmount: number,
-    readonly collector: AsyncReducer<T, R>
-  ) {
-    super();
-  }
-
-  [Symbol.asyncIterator](): AsyncFastIterator<R> {
-    return new AsyncWindowIterator<T, R>(
-      this.source[Symbol.asyncIterator](),
-      this.windowSize,
-      this.skipAmount,
-      this.collector
-    );
-  }
-}
-
-class AsyncReduceStream<I, R> extends AsyncStreamBase<R> {
+class AsyncReduceStream<I, R = I> extends AsyncStreamBase<R> {
   constructor(
     readonly source: AsyncStream<I>,
     readonly reducer: AsyncReducer<I, R>
@@ -1416,7 +1655,23 @@ class AsyncReduceStream<I, R> extends AsyncStreamBase<R> {
   [Symbol.asyncIterator](): AsyncFastIterator<R> {
     return new AsyncReduceIterator<I, R>(
       this.source[Symbol.asyncIterator](),
-      this.reducer.compile()
+      this.reducer
+    );
+  }
+}
+
+export class AsyncTransformerStream<T, R = T> extends AsyncStreamBase<R> {
+  constructor(
+    readonly source: AsyncStream<T>,
+    readonly transformer: AsyncTransformer.Accept<T, R>
+  ) {
+    super();
+  }
+
+  [Symbol.asyncIterator](): AsyncFastIterator<R> {
+    return new AsyncTransformerFastIterator<T, R>(
+      this.source[Symbol.asyncIterator](),
+      this.transformer
     );
   }
 }
@@ -1491,20 +1746,16 @@ class AsyncEmptyStream<T = any>
     return this as any;
   }
   transform<R>(transformer: AsyncTransformer<T, R>): AsyncStream<R> {
-    return AsyncStreamConstructorsImpl.from<R>(
-      async () => await transformer.stateToResult(await transformer.init())
-    );
+    return fromAsyncStreamSource<R>(async () => {
+      const instance = await transformer.compile();
+
+      return instance.getOutput();
+    });
   }
-  filter(): AsyncStream<T> {
+  filter(): any {
     return this;
   }
-  filterNot(): AsyncStream<T> {
-    return this;
-  }
-  filterPure(): AsyncStream<T> {
-    return this;
-  }
-  filterNotPure(): AsyncStream<T> {
+  filterPure(): any {
     return this;
   }
   collect<R>(): AsyncStream<R> {
@@ -1606,9 +1857,7 @@ class AsyncEmptyStream<T = any>
     end = '',
     ifEmpty = undefined,
   } = {}): Promise<string> {
-    if (undefined !== ifEmpty) return ifEmpty;
-
-    return start.concat(end);
+    return undefined !== ifEmpty ? ifEmpty : start.concat(end);
   }
   mkGroup({
     start = emptyAsyncStream as AsyncStreamSource<T>,
@@ -1622,7 +1871,7 @@ class AsyncEmptyStream<T = any>
   splitWhere<R>(): AsyncStream<R> {
     return this as any;
   }
-  splitOnSeq<R>(): AsyncStream<R> {
+  splitOnSlice<R>(): AsyncStream<R> {
     return this as any;
   }
   distinctPrevious(): AsyncStream<T> {
@@ -1639,8 +1888,9 @@ class AsyncEmptyStream<T = any>
   }
   async reduce(shape: any): Promise<any> {
     const reducer = AsyncReducer.combine(shape);
+    const instance = await reducer.compile();
 
-    return reducer.stateToResult(await reducer.init());
+    return instance.getOutput();
   }
   reduceStream(): any {
     return this;
@@ -1835,7 +2085,7 @@ export const AsyncStreamConstructorsImpl: AsyncStreamConstructors =
       );
     },
     flatten(source: any) {
-      return AsyncStreamConstructorsImpl.from(source).flatMap((s: any) => s);
+      return fromAsyncStreamSource(source).flatMap((s: any) => s);
     },
     unzip(source, options) {
       const { length } = options;

--- a/packages/stream/src/async-custom/async-stream-custom.mts
+++ b/packages/stream/src/async-custom/async-stream-custom.mts
@@ -34,6 +34,7 @@ import {
   AsyncReduceIterator,
   AsyncRepeatIterator,
   AsyncTakeIterator,
+  AsyncTransformerFastIterator,
   AsyncUnfoldIterator,
   AsyncZipAllWithItererator,
   AsyncZipWithIterator,
@@ -45,7 +46,6 @@ import {
   emptyAsyncFastIterator,
   isAsyncFastIterator,
   type AsyncStreamConstructors,
-  AsyncTransformerFastIterator,
 } from '@rimbu/stream/async-custom';
 import {
   StreamConstructorsImpl,
@@ -522,7 +522,7 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
 
   async containsSlice(
     source: AsyncStreamSource.NonEmpty<T>,
-    options: { eq?: Eq<T>; negate?: boolean } = {}
+    options: { eq?: Eq<T>; amount?: number } = {}
   ): Promise<boolean> {
     return (this as AsyncStream<T>).reduce(
       AsyncReducer.containsSlice(source, options)
@@ -965,22 +965,6 @@ class AsyncPrependStream<T> extends AsyncStreamBase<T> {
     return compare(result, itemValue) > 0 ? result : itemValue;
   }
 
-  async join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): Promise<string> {
-    return this.source.join({
-      sep,
-      start: `${start}${valueToString(
-        await AsyncOptLazy.toMaybePromise(this.item)
-      )}`,
-      end,
-      valueToString,
-    });
-  }
-
   async toArray(): Promise<T[]> {
     const result = await this.source.toArray();
     result.unshift(await AsyncOptLazy.toMaybePromise(this.item));
@@ -1063,22 +1047,6 @@ class AsyncAppendStream<T> extends AsyncStreamBase<T> {
     }
 
     return compare(result, itemValue) > 0 ? result : itemValue;
-  }
-
-  async join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): Promise<string> {
-    return this.source.join({
-      sep,
-      start,
-      end: `${valueToString(
-        await AsyncOptLazy.toMaybePromise(this.item)
-      )}${end}`,
-      valueToString,
-    });
   }
 
   async toArray(): Promise<T[]> {

--- a/packages/stream/src/async/async-fast-iterator.mts
+++ b/packages/stream/src/async/async-fast-iterator.mts
@@ -1,7 +1,24 @@
 import type { AsyncOptLazy, MaybePromise } from '@rimbu/common';
 
+/**
+ * An asynchronous iterator that extends the default `AsyncIterator` interface with methods for improved performance.
+ * @typeparam T - the element type
+ */
 export interface AsyncFastIterator<T> extends AsyncIterator<T> {
+  /**
+   * Returns the next iterator value asynchronously, or the given `otherwise` `AsyncOptLazy` value instead.
+   */
   fastNext(): MaybePromise<T | undefined>;
+
+  /**
+   * Returns the next iterator value asynchronously, or the given `otherwise` `AsyncOptLazy` value instead.
+   * @param otherwise - (default: undefined) the value to return if the iterator has no more values
+   * @typeparam O - the type of the alternative value
+   */
   fastNext<O>(otherwise: AsyncOptLazy<O>): MaybePromise<T | O>;
+
+  /**
+   * Returns a promise resolving to the next `IteratorResult`.
+   */
   next(): Promise<IteratorResult<T>>;
 }

--- a/packages/stream/src/async/async-reducer.mts
+++ b/packages/stream/src/async/async-reducer.mts
@@ -775,9 +775,12 @@ export namespace AsyncReducer {
 
   export function from<I, O>(reducer: Reducer<I, O>): AsyncReducer<I, O> {
     return AsyncReducer.create(
-      reducer.init,
+      () =>
+        reducer.init(() => {
+          //
+        }),
       reducer.next,
-      reducer.stateToResult
+      reducer.stateToResult as any
     );
   }
 

--- a/packages/stream/src/async/async-reducer.mts
+++ b/packages/stream/src/async/async-reducer.mts
@@ -357,7 +357,10 @@ export namespace AsyncReducer {
      * // => 3
      * ```
      */
-    sliceInput(from?: number, amount?: number): AsyncReducer<I, O>;
+    sliceInput(
+      from?: number | undefined,
+      amount?: number | undefined
+    ): AsyncReducer<I, O>;
     /**
      * Returns an 'AsyncReducer` instance that produces at most `amount` values.
      * @param amount - the maximum amount of values to produce.
@@ -375,7 +378,7 @@ export namespace AsyncReducer {
      */
     takeOutputUntil(
       pred: (value: O, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
+      options?: { negate?: boolean | undefined }
     ): AsyncReducer<I, O>;
     /**
      * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
@@ -1264,7 +1267,7 @@ export namespace AsyncReducer {
    */
   export function some<T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
+    options: { negate?: boolean | undefined } = {}
   ): AsyncReducer<T, boolean> {
     return nonEmpty.filterInput(pred, options);
   }
@@ -1278,7 +1281,7 @@ export namespace AsyncReducer {
    */
   export function every<T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
+    options: { negate?: boolean | undefined } = {}
   ): AsyncReducer<T, boolean> {
     const { negate = false } = options;
 
@@ -1295,7 +1298,7 @@ export namespace AsyncReducer {
    */
   export function equals<T>(
     other: AsyncStreamSource<T>,
-    options: { eq?: Eq<T>; negate?: boolean } = {}
+    options: { eq?: Eq<T> | undefined; negate?: boolean | undefined } = {}
   ): AsyncReducer<T, boolean> {
     const { eq = Eq.objectIs, negate = false } = options;
 
@@ -1504,7 +1507,7 @@ export namespace AsyncReducer {
    */
   export function containsSlice<T>(
     slice: AsyncStreamSource<T>,
-    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+    options: { eq?: Eq<T> | undefined; amount?: number | undefined } = {}
   ): AsyncReducer<T, boolean> {
     const { eq, amount = 1 } = options;
 
@@ -1525,21 +1528,6 @@ export namespace AsyncReducer {
    * @typeparam RT - the reducer result type for the `collectorTrue` value
    * @typeparam RF - the reducer result type for the `collectorFalse` value
    * @note if the predicate is a type guard, the return type is automatically inferred
-   * @example
-   * ```ts
-   * Stream.of(1, 2, 3).partition((v) => v % 2 === 0)
-   * // => [[2], [1, 3]]
-   *
-   * Stream.of<number | string>(1, 'a', 'b', 2)
-   *   .partition((v): v is string => typeof v === 'string')
-   * // => [['a', 'b'], [1, 2]]
-   * // return type is: [string[], number[]]
-   *
-   * Stream.of(1, 2, 3, 4).partition(
-   *   (v) => v % 2 === 0,
-   *   { collectorTrue: Reducer.toJSSet(), collectorFalse: Reducer.sum }
-   * )
-   * // => [Set(2, 4), 4]
    * ```
    */
   export const partition: {
@@ -1613,10 +1601,6 @@ export namespace AsyncReducer {
    * @typeparam T - the input value type
    * @typeparam K - the key type
    * @typeparam R - the collector output type
-   * @example
-   * ```ts
-   * await AsyncStream.of(1, 2, 3).groupBy((v) => v % 2)
-   * // => Map {0 => [2], 1 => [1, 3]}
    * ```
    */
   export const groupBy: {

--- a/packages/stream/src/async/async-reducer.mts
+++ b/packages/stream/src/async/async-reducer.mts
@@ -1,13 +1,22 @@
+import { RimbuError } from '@rimbu/base';
 import {
   AsyncOptLazy,
+  CollectFun,
+  Eq,
+  ErrBase,
   type AsyncCollectFun,
   type MaybePromise,
-  CollectFun,
-  type Eq,
-  ErrBase,
 } from '@rimbu/common';
-import { Stream, type AsyncStreamSource, type Reducer } from '@rimbu/stream';
-import { fromAsyncStreamSource } from '../async-custom/async-stream-custom.mjs';
+import {
+  Reducer,
+  Stream,
+  type AsyncFastIterator,
+  type AsyncStreamSource,
+} from '@rimbu/stream';
+import {
+  AsyncStreamConstructorsImpl,
+  fromAsyncStreamSource,
+} from '../async-custom/async-stream-custom.mjs';
 
 /**
  * An `AsyncReducer` is a stand-alone asynchronous calculation that takes input values of type I,
@@ -22,29 +31,45 @@ function identity<T>(value: T): T {
 }
 
 function combineArr<T, R extends readonly [unknown, unknown, ...unknown[]]>(
-  ...reducers: { [K in keyof R]: AsyncReducer<T, R[K]> } & AsyncReducer<
+  ...reducers: { [K in keyof R]: AsyncReducer.Accept<T, R[K]> } & AsyncReducer<
     T,
     unknown
   >[]
 ): AsyncReducer<T, R> {
   return AsyncReducer.create<T, any, AsyncReducer.Instance<T, unknown>[]>(
-    () => reducers.map((reducer) => reducer.compile()),
+    async (initHalt) => {
+      let allHalted = true;
+
+      const result = await Promise.all(
+        reducers.map(async (reducer) => {
+          const instance = await AsyncReducer.from(reducer).compile();
+
+          allHalted = allHalted && instance.halted;
+
+          return instance;
+        })
+      );
+
+      if (allHalted) {
+        initHalt();
+      }
+
+      return result;
+    },
     async (state, elem, index, halt) => {
-      let anyNotHalted = false;
+      let allHalted = true;
 
       await Promise.all(
-        Stream.from(state).map(async (reducer) => {
+        Stream.from(state).mapPure(async (reducer) => {
           if (reducer.halted) return;
 
           await reducer.next(elem);
 
-          if (!reducer.halted) {
-            anyNotHalted = true;
-          }
+          allHalted = allHalted && reducer.halted;
         })
       );
 
-      if (!anyNotHalted) {
+      if (allHalted) {
         halt();
       }
 
@@ -52,45 +77,60 @@ function combineArr<T, R extends readonly [unknown, unknown, ...unknown[]]>(
     },
     (state) =>
       Promise.all(
-        Stream.from(state).map((reducerInstance) => reducerInstance.getOutput())
+        Stream.from(state).mapPure((reducerInstance) =>
+          reducerInstance.getOutput()
+        )
       ),
     async (state, err) => {
       await Promise.all(
-        Stream.from(state).map((reducer) => reducer.onClose(err))
+        Stream.from(state).mapPure((reducer) => reducer.onClose(err))
       );
     }
   );
 }
 
 function combineObj<T, R extends { readonly [key: string]: unknown }>(
-  reducerObj: { readonly [K in keyof R]: AsyncReducer<T, R[K]> } & Record<
-    string,
-    AsyncReducer<T, unknown>
-  >
+  reducerObj: {
+    readonly [K in keyof R]: AsyncReducer.Accept<T, R[K]>;
+  } & Record<string, AsyncReducer.Accept<T, unknown>>
 ): AsyncReducer<T, R> {
   return AsyncReducer.create(
-    () => {
+    async (initHalt) => {
       const result: Record<string, AsyncReducer.Instance<T, any>> = {};
 
-      for (const key in reducerObj) {
-        result[key] = reducerObj[key].compile();
+      let allHalted = true;
+
+      await Promise.all(
+        Stream.fromObject(
+          reducerObj as Record<string, AsyncReducer.Accept<T, unknown>>
+        ).mapPure(async ([key, reducer]) => {
+          const instance = await AsyncReducer.from(reducer).compile();
+          result[key] = instance;
+
+          allHalted = allHalted && instance.halted;
+        })
+      );
+
+      if (allHalted) {
+        initHalt();
       }
 
       return result;
     },
     async (state, elem, index, halt) => {
-      let anyNotHalted = false;
+      let allHalted = true;
 
       await Promise.all(
-        Stream.fromObjectValues(state).map(async (reducerInstance) => {
+        Stream.fromObjectValues(state).mapPure(async (reducerInstance) => {
           if (!reducerInstance.halted) {
             await reducerInstance.next(elem);
-            anyNotHalted = anyNotHalted || !reducerInstance.halted;
+
+            allHalted = allHalted && reducerInstance.halted;
           }
         })
       );
 
-      if (!anyNotHalted) {
+      if (allHalted) {
         halt();
       }
 
@@ -100,7 +140,7 @@ function combineObj<T, R extends { readonly [key: string]: unknown }>(
       const result: any = {};
 
       await Promise.all(
-        Stream.fromObject(state).map(async ([key, reducerInstance]) => {
+        Stream.fromObject(state).mapPure(async ([key, reducerInstance]) => {
           result[key] = await reducerInstance.getOutput();
         })
       );
@@ -109,7 +149,7 @@ function combineObj<T, R extends { readonly [key: string]: unknown }>(
     },
     async (state, err) => {
       await Promise.all(
-        Stream.fromObjectValues(state).map((reducerInstance) =>
+        Stream.fromObjectValues(state).mapPure((reducerInstance) =>
           reducerInstance.onClose(err)
         )
       );
@@ -118,11 +158,13 @@ function combineObj<T, R extends { readonly [key: string]: unknown }>(
 }
 
 export namespace AsyncReducer {
+  export type Accept<I, O> = AsyncReducer<I, O> | Reducer<I, O>;
+
   export interface Impl<I, O, S> {
     /**
      * The initial state value for the reducer algorithm.
      */
-    readonly init: () => MaybePromise<S>;
+    readonly init: (initHalt: () => void) => MaybePromise<S>;
     /**
      * Returns the next state based on the given input values
      * @param state - the current state
@@ -135,7 +177,7 @@ export namespace AsyncReducer {
      * Returns the output value based on the given `state`
      * @param state - the current state
      */
-    stateToResult(state: S): MaybePromise<O>;
+    stateToResult(state: S, index: number, halted: boolean): MaybePromise<O>;
     /**
      * An optional function that is called when the reducer will no longer receive values.
      * @param state - the final reducer state
@@ -156,8 +198,21 @@ export namespace AsyncReducer {
      * // this reducer will only sum values larger than 10
      * ```
      */
+    filterInput<IF extends I>(
+      pred: (value: I, index: number, halt: () => void) => value is IF,
+      options?: { negate?: false | undefined }
+    ): AsyncReducer<IF, O>;
+    filterInput<IF extends I>(
+      pred: (value: I, index: number, halt: () => void) => value is IF,
+      options: { negate: true }
+    ): AsyncReducer<Exclude<I, IF>, O>;
     filterInput(
-      pred: (value: I, index: number, halt: () => void) => MaybePromise<boolean>
+      pred: (
+        value: I,
+        index: number,
+        halt: () => void
+      ) => MaybePromise<boolean>,
+      options?: { negate?: boolean | undefined }
     ): AsyncReducer<I, O>;
     /**
      * Returns an `AsyncReducer` instance that converts its input values using given `mapFun` before passing them to the reducer.
@@ -272,6 +327,11 @@ export namespace AsyncReducer {
      * ```
      */
     sliceInput(from?: number, amount?: number): AsyncReducer<I, O>;
+    takeOutput(amount: number): AsyncReducer<I, O>;
+    takeOutputWhile(
+      pred: (value: O, index: number) => MaybePromise<boolean>,
+      options?: { negate?: boolean }
+    ): AsyncReducer<I, O>;
     /**
      * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
      * by the previous reducer.
@@ -296,28 +356,28 @@ export namespace AsyncReducer {
      * // => 9
      * ```
      */
-    pipe<O1>(nextReducer1: AsyncReducer<O, O1>): AsyncReducer<I, O1>;
+    pipe<O1>(nextReducer1: AsyncReducer.Accept<O, O1>): AsyncReducer<I, O1>;
     pipe<O1, O2>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>
     ): AsyncReducer<I, O2>;
     pipe<O1, O2, O3>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>,
-      nextReducer3: AsyncReducer<O2, O3>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>,
+      nextReducer3: AsyncReducer.Accept<O2, O3>
     ): AsyncReducer<I, O3>;
     pipe<O1, O2, O3, O4>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>,
-      nextReducer3: AsyncReducer<O2, O3>,
-      nextReducer4: AsyncReducer<O3, O4>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>,
+      nextReducer3: AsyncReducer.Accept<O2, O3>,
+      nextReducer4: AsyncReducer.Accept<O3, O4>
     ): AsyncReducer<I, O4>;
     pipe<O1, O2, O3, O4, O5>(
-      nextReducer1: AsyncReducer<O, O1>,
-      nextReducer2: AsyncReducer<O1, O2>,
-      nextReducer3: AsyncReducer<O2, O3>,
-      nextReducer4: AsyncReducer<O3, O4>,
-      nextReducer5: AsyncReducer<O4, O5>
+      nextReducer1: AsyncReducer.Accept<O, O1>,
+      nextReducer2: AsyncReducer.Accept<O1, O2>,
+      nextReducer3: AsyncReducer.Accept<O2, O3>,
+      nextReducer4: AsyncReducer.Accept<O3, O4>,
+      nextReducer5: AsyncReducer.Accept<O4, O5>
     ): AsyncReducer<I, O5>;
     /**
      * Returns a reducer that applies the given `nextReducers` sequentially after this reducer
@@ -339,29 +399,29 @@ export namespace AsyncReducer {
      * ```
      */
     chain<O1>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>
     ): AsyncReducer<I, O1>;
     chain<O1, O2>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>
     ): AsyncReducer<I, O2>;
     chain<O1, O2, O3>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>,
-      nextReducer3: AsyncOptLazy<AsyncReducer<I, O3>, [O2]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
+      nextReducer3: AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>
     ): AsyncReducer<I, O3>;
     chain<O1, O2, O3, O4>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>,
-      nextReducer3: AsyncOptLazy<AsyncReducer<I, O3>, [O2]>,
-      nextReducer4: AsyncOptLazy<AsyncReducer<I, O4>, [O3]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
+      nextReducer3: AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
+      nextReducer4: AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>
     ): AsyncReducer<I, O4>;
     chain<O1, O2, O3, O4, O5>(
-      nextReducer1: AsyncOptLazy<AsyncReducer<I, O1>, [O]>,
-      nextReducer2: AsyncOptLazy<AsyncReducer<I, O2>, [O1]>,
-      nextReducer3: AsyncOptLazy<AsyncReducer<I, O3>, [O2]>,
-      nextReducer4: AsyncOptLazy<AsyncReducer<I, O4>, [O3]>,
-      nextReducer5: AsyncOptLazy<AsyncReducer<I, O5>, [O4]>
+      nextReducer1: AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
+      nextReducer2: AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
+      nextReducer3: AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
+      nextReducer4: AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>,
+      nextReducer5: AsyncOptLazy<AsyncReducer.Accept<I, O5>, [O4]>
     ): AsyncReducer<I, O5>;
     /**
      * Returns a 'runnable' instance of the current reducer specification. This instance maintains its own state
@@ -377,7 +437,7 @@ export namespace AsyncReducer {
      * // => 16
      * ```
      */
-    compile(): AsyncReducer.Instance<I, O>;
+    compile(): Promise<AsyncReducer.Instance<I, O>>;
   }
 
   /**
@@ -388,14 +448,18 @@ export namespace AsyncReducer {
    */
   export class Base<I, O, S> implements AsyncReducer.Impl<I, O, S> {
     constructor(
-      readonly init: () => MaybePromise<S>,
+      readonly init: (initHalt: () => void) => MaybePromise<S>,
       readonly next: (
         state: S,
         elem: I,
         index: number,
         halt: () => void
       ) => MaybePromise<S>,
-      readonly stateToResult: (state: S) => MaybePromise<O>,
+      readonly stateToResult: (
+        state: S,
+        index: number,
+        halted: boolean
+      ) => MaybePromise<O>,
       readonly onClose?: (state: S, error?: unknown) => MaybePromise<void>
     ) {}
 
@@ -405,11 +469,11 @@ export namespace AsyncReducer {
         index: number,
         halt: () => void
       ) => MaybePromise<boolean>,
-      options: { negate?: boolean } = {}
-    ): AsyncReducer<I, O> {
+      options: { negate?: boolean | undefined } = {}
+    ): any {
       const { negate = false } = options;
 
-      return create(
+      return create<I, any>(
         () => this.compile(),
         async (state, elem, index, halt) => {
           if ((await pred(elem, index, halt)) !== negate) {
@@ -499,7 +563,58 @@ export namespace AsyncReducer {
       return create(
         this.init,
         this.next,
-        async (state): Promise<O2> => mapFun(await this.stateToResult(state)),
+        async (state, index, halted): Promise<O2> =>
+          mapFun(await this.stateToResult(state, index, halted)),
+        this.onClose
+      );
+    }
+
+    takeOutput(amount: number): AsyncReducer<I, O> {
+      if (amount <= 0) {
+        return create(
+          (initHalt) => {
+            initHalt();
+            return this.init(initHalt);
+          },
+          this.next,
+          this.stateToResult,
+          this.onClose
+        );
+      }
+
+      return create(
+        this.init,
+        (state, next, index, halt) => {
+          if (index >= amount) {
+            halt();
+          }
+          return this.next(state, next, index, halt);
+        },
+        this.stateToResult,
+        this.onClose
+      );
+    }
+
+    takeOutputWhile(
+      pred: (value: O, index: number) => MaybePromise<boolean>,
+      options: { negate?: boolean } = {}
+    ): AsyncReducer<I, O> {
+      const { negate = false } = options;
+
+      return create(
+        this.init,
+        async (state, next, index, halt) => {
+          const nextState = await this.next(state, next, index, halt);
+
+          const nextOutput = await this.stateToResult(nextState, index, false);
+
+          if ((await pred(nextOutput, index)) === negate) {
+            halt();
+          }
+
+          return state;
+        },
+        this.stateToResult,
         this.onClose
       );
     }
@@ -534,22 +649,36 @@ export namespace AsyncReducer {
       return this.takeInput(amount).dropInput(from);
     }
 
-    pipe<O2>(...nextReducers: AsyncReducer<O, O2>[]): AsyncReducer<I, O2> {
+    pipe<O2>(
+      ...nextReducers: AsyncReducer.Accept<O, O2>[]
+    ): AsyncReducer<I, O2> {
       if (nextReducers.length <= 0) {
         return this as any;
       }
 
-      const [nextReducer, ...others] = nextReducers as AsyncReducer<any, any>[];
+      const [nextReducer, ...others] = nextReducers as AsyncReducer.Accept<
+        any,
+        any
+      >[];
 
       if (others.length > 0) {
         return (this.pipe(nextReducer).pipe as any)(...others);
       }
 
       return AsyncReducer.create(
-        () => ({
-          thisInstance: this.compile(),
-          nextInstance: nextReducer.compile(),
-        }),
+        async (inithalt) => {
+          const thisInstance = await this.compile();
+          const nextInstance = await AsyncReducer.from(nextReducer).compile();
+
+          if (thisInstance.halted || nextInstance.halted) {
+            inithalt();
+          }
+
+          return {
+            thisInstance,
+            nextInstance,
+          };
+        },
         async (state, next, index, halt) => {
           const { thisInstance, nextInstance } = state;
 
@@ -562,7 +691,13 @@ export namespace AsyncReducer {
 
           return state;
         },
-        (state) => state.nextInstance.getOutput(),
+        async (state, index, halted) => {
+          if (halted && index === 0) {
+            await state.nextInstance.next(await state.thisInstance.getOutput());
+          }
+
+          return state.nextInstance.getOutput();
+        },
         async (state, err) => {
           await Promise.all([
             state.thisInstance.onClose(err),
@@ -573,12 +708,12 @@ export namespace AsyncReducer {
     }
 
     chain(
-      ...nextReducers: AsyncOptLazy<AsyncReducer<I, any>, [any]>[]
+      ...nextReducers: AsyncOptLazy<AsyncReducer.Accept<I, any>, [any]>[]
     ): AsyncReducer<I, O> {
       return AsyncReducer.create(
-        () => ({
+        async () => ({
           activeIndex: -1,
-          activeInstance: this.compile() as AsyncReducer.Instance<I, O>,
+          activeInstance: (await this.compile()) as AsyncReducer.Instance<I, O>,
         }),
         async (state, next, index, halt) => {
           while (state.activeInstance.halted) {
@@ -590,7 +725,9 @@ export namespace AsyncReducer {
               nextReducers[++state.activeIndex],
               await state.activeInstance.getOutput()
             );
-            state.activeInstance = nextReducer.compile();
+            state.activeInstance = await AsyncReducer.from(
+              nextReducer
+            ).compile();
           }
 
           await state.activeInstance.next(next);
@@ -609,14 +746,17 @@ export namespace AsyncReducer {
       );
     }
 
-    compile(): AsyncReducer.Instance<I, O> {
-      return new AsyncReducer.InstanceImpl(this);
+    async compile(): Promise<AsyncReducer.Instance<I, O>> {
+      const instance = new AsyncReducer.InstanceImpl(this);
+      await instance.initialize();
+      return instance;
     }
   }
 
   export interface Instance<I, O> {
     get halted(): boolean;
     get index(): number;
+    halt(): void;
     next(value: I): MaybePromise<void>;
     getOutput(): MaybePromise<O>;
     onClose(err?: unknown): Promise<void>;
@@ -625,26 +765,29 @@ export namespace AsyncReducer {
   export class InstanceImpl<I, O, S> implements AsyncReducer.Instance<I, O> {
     constructor(readonly reducer: AsyncReducer.Impl<I, O, S>) {}
 
-    #initialized = false;
-    #_state: S | undefined;
+    #state: S | undefined;
     #index = 0;
+    #initialized = false;
     #halted = false;
     #closed = false;
 
-    async #getState(): Promise<S> {
-      if (!this.#initialized) {
-        this.#_state = await this.reducer.init();
-        this.#initialized = true;
+    async initialize(): Promise<void> {
+      if (this.#closed) {
+        throw new AsyncReducer.ReducerClosedError();
       }
 
-      return this.#_state as S;
+      this.#state = await this.reducer.init(this.halt);
+      this.#initialized = true;
     }
 
-    set #state(value: S) {
-      this.#_state = value;
-    }
+    halt = (): void => {
+      if (this.#closed) {
+        throw new AsyncReducer.ReducerClosedError();
+      }
+      if (!this.#initialized) {
+        throw new AsyncReducer.ReducerNotInitializedError();
+      }
 
-    #halt = (): void => {
       this.#halted = true;
     };
 
@@ -657,30 +800,40 @@ export namespace AsyncReducer {
     }
 
     next = async (value: I): Promise<void> => {
+      if (!this.#initialized) {
+        throw new AsyncReducer.ReducerNotInitializedError();
+      }
+      if (this.#closed) {
+        throw new AsyncReducer.ReducerClosedError();
+      }
       if (this.#halted) {
         throw new AsyncReducer.ReducerHaltedError();
       }
 
       this.#state = await this.reducer.next(
-        await this.#getState(),
+        this.#state!,
         value,
         this.#index++,
-        this.#halt
+        this.halt
       );
     };
 
     async getOutput(): Promise<O> {
-      return this.reducer.stateToResult(await this.#getState());
+      if (!this.#initialized) {
+        throw new AsyncReducer.ReducerNotInitializedError();
+      }
+
+      return this.reducer.stateToResult(this.#state!, this.index, this.halted);
     }
 
     async onClose(err?: unknown): Promise<void> {
       if (this.#closed) {
-        throw Error('already closed');
+        throw new AsyncReducer.ReducerClosedError();
       }
 
       this.#closed = true;
 
-      await this.reducer.onClose?.(await this.#getState(), err);
+      await this.reducer.onClose?.(this.#state!, err);
     }
   }
 
@@ -699,14 +852,18 @@ export namespace AsyncReducer {
    * @typeparam S - the internal state type
    */
   export function create<I, O = I, S = O>(
-    init: () => MaybePromise<S>,
+    init: (initHalt: () => void) => MaybePromise<S>,
     next: (
       current: S,
       next: I,
       index: number,
       halt: () => void
     ) => MaybePromise<S>,
-    stateToResult: (state: S) => MaybePromise<O>,
+    stateToResult: (
+      state: S,
+      index: number,
+      halted: boolean
+    ) => MaybePromise<O>,
     onClose?: (state: S, error?: unknown) => MaybePromise<void>
   ): AsyncReducer<I, O> {
     return new AsyncReducer.Base(
@@ -732,14 +889,18 @@ export namespace AsyncReducer {
    * @typeparam S - the internal state type
    */
   export function createMono<T>(
-    init: () => MaybePromise<T>,
+    init: (initHalt: () => void) => MaybePromise<T>,
     next: (
       current: T,
       next: T,
       index: number,
       halt: () => void
     ) => MaybePromise<T>,
-    stateToResult?: (state: T) => MaybePromise<T>,
+    stateToResult?: (
+      state: T,
+      index: number,
+      halted: boolean
+    ) => MaybePromise<T>,
     onClose?: (state: T, error?: unknown) => MaybePromise<void>
   ): AsyncReducer<T> {
     return create(init, next, stateToResult ?? identity, onClose);
@@ -760,71 +921,51 @@ export namespace AsyncReducer {
    * @typeparam S - the internal state type
    */
   export function createOutput<I, O = I>(
-    init: () => MaybePromise<O>,
+    init: (initHalt: () => void) => MaybePromise<O>,
     next: (
       current: O,
       next: I,
       index: number,
       halt: () => void
     ) => MaybePromise<O>,
-    stateToResult?: (state: O) => MaybePromise<O>,
+    stateToResult?: (
+      state: O,
+      index: number,
+      halted: boolean
+    ) => MaybePromise<O>,
     onClose?: (state: O, error?: unknown) => MaybePromise<void>
   ): AsyncReducer<I, O> {
     return create(init, next, stateToResult ?? identity, onClose);
   }
 
-  export function from<I, O>(reducer: Reducer<I, O>): AsyncReducer<I, O> {
+  export function fold<T, R>(
+    init: AsyncOptLazy<R>,
+    next: (
+      current: R,
+      value: T,
+      index: number,
+      halt: () => void
+    ) => MaybePromise<R>
+  ): AsyncReducer<T, R> {
+    return AsyncReducer.createOutput(
+      () => AsyncOptLazy.toMaybePromise(init),
+      next
+    );
+  }
+
+  export function from<I, O>(
+    reducer: AsyncReducer.Accept<I, O>
+  ): AsyncReducer<I, O> {
+    if (reducer instanceof AsyncReducer.Base) {
+      return reducer;
+    }
+
     return AsyncReducer.create(
-      () =>
-        reducer.init(() => {
-          //
-        }),
+      reducer.init,
       reducer.next,
       reducer.stateToResult as any
     );
   }
-
-  /**
-   * A `Reducer` that sums all given numeric input values.
-   * @example
-   * ```ts
-   * console.log(Stream.range({ amount: 5 }).reduce(Reducer.sum))
-   * // => 10
-   * ```
-   */
-  export const sum = createMono(
-    () => 0,
-    (state, next): number => state + next
-  );
-
-  /**
-   * A `Reducer` that calculates the product of all given numeric input values.
-   * @example
-   * ```ts
-   * console.log(Stream.range({ start: 1, amount: 5 }).reduce(product))
-   * // => 120
-   * ```
-   */
-  export const product = createMono(
-    () => 1,
-    (state, next, _, halt): number => {
-      if (0 === next) halt();
-      return state * next;
-    }
-  );
-
-  /**
-   * A `Reducer` that calculates the average of all given numberic input values.
-   * @example
-   * ```ts
-   * console.log(Stream.range({ amount: 5 }).reduce(Reducer.average));
-   * // => 2
-   * ```
-   */
-  export const average = createMono(
-    () => 0,
-    (avg, value, index): number => avg + (value - avg) / (index + 1)
-  );
 
   /**
    * Returns a `Reducer` that remembers the minimum value of the inputs using the given `compFun` to compare input values
@@ -851,6 +992,7 @@ export namespace AsyncReducer {
     otherwise?: AsyncOptLazy<O>
   ) => {
     const token = Symbol();
+
     return create<T, T | O, T | typeof token>(
       () => token,
       async (state, next): Promise<T> => {
@@ -946,124 +1088,6 @@ export namespace AsyncReducer {
   };
 
   /**
-   * Returns a `Reducer` that joins the given input values into a string using the given options.
-   * @param options - an object containing:<br/>
-   * - sep: (optional) a seperator string value between values in the output<br/>
-   * - start: (optional) a start string to prepend to the output<br/>
-   * - end: (optional) an end string to append to the output<br/>
-   * @example
-   * ```ts
-   * console.log(Stream.of(1, 2, 3).reduce(Reducer.join({ sep: '-' })))
-   * // => '1-2-3'
-   * ```
-   */
-  export function join<T>({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String as (value: T) => string,
-  } = {}): AsyncReducer<T, string> {
-    return create(
-      () => ({ result: '', curSep: '', curStart: start }),
-      (state, next) => {
-        state.result = state.curStart.concat(
-          state.result,
-          state.curSep,
-          valueToString(next)
-        );
-        state.curSep = sep;
-        state.curStart = '';
-
-        return state;
-      },
-      (state): string => state.result.concat(end)
-    );
-  }
-
-  /**
-   * Returns an `AsyncReducer` that remembers the amount of input items provided.
-   * @param pred - (optional) a predicate that returns false if the item should not be counted given:<br/>
-   * - value: the current input value<br/>
-   * - index: the input value index
-   * @example
-   * ```ts
-   * const stream = AsyncStream.from(Stream.range({ amount: 10 }))
-   * console.log(await stream.reduce(AsyncReducer.count()))
-   * // => 10
-   * console.log(await stream.reduce(AsyncReducer.count(async v => v < 5)))
-   * // => 5
-   * ```
-   */
-  export const count: {
-    (): AsyncReducer<never, number>;
-    <T>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
-    ): AsyncReducer<T, number>;
-  } = (
-    pred?: (value: any, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean } = {}
-  ): AsyncReducer<never, number> => {
-    if (undefined === pred)
-      return createOutput(
-        () => 0,
-        (_, __, i): number => i + 1
-      );
-
-    const { negate = false } = options;
-
-    return createOutput(
-      () => 0,
-      async (state, next, i): Promise<number> => {
-        if ((await pred(next, i)) !== negate) return state + 1;
-        return state;
-      }
-    );
-  };
-
-  /**
-   * Returns an `AsyncReducer` that remembers the first input value for which the given `pred` function returns true.
-   * @param pred - a function taking an input value and its index, and returning true if the value should be remembered
-   * @param otherwise - (default: undefined) a fallback value to output if no input value yet has satisfied the given predicate
-   * @typeparam T - the input value type
-   * @typeparam O - the fallback value type
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range({ amount: 10 })).reduce(AsyncReducer.firstWhere(async v => v > 5)))
-   * // => 6
-   * ```
-   */
-  export const firstWhere: {
-    <T>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
-    ): AsyncReducer<T, T | undefined>;
-    <T, O>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean; otherwise: AsyncOptLazy<O> }
-    ): AsyncReducer<T, T | O>;
-  } = <T, O>(
-    pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean; otherwise?: AsyncOptLazy<O> } = {}
-  ) => {
-    const token = Symbol();
-    const { negate = false, otherwise } = options;
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
-      async (state, next, i, halt): Promise<T | typeof token> => {
-        if (token === state && (await pred(next, i)) !== negate) {
-          halt();
-          return next;
-        }
-        return state;
-      },
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
-    );
-  };
-
-  /**
    * Returns an `AsyncReducer` that remembers the first input value.
    * @param otherwise - (default: undefined) a fallback value to output if no input value has been provided
    * @typeparam T - the input value type
@@ -1078,56 +1102,14 @@ export namespace AsyncReducer {
     <T>(): AsyncReducer<T, T | undefined>;
     <T, O>(otherwise: AsyncOptLazy<O>): AsyncReducer<T, T | O>;
   } = <T, O>(otherwise?: AsyncOptLazy<O>): AsyncReducer<T, T | O> => {
-    const token = Symbol();
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
+    return create<T, T | O, T | undefined>(
+      () => undefined,
       (state, next, _, halt): T => {
         halt();
-        if (token === state) return next;
-        return state;
+        return next;
       },
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
-    );
-  };
-
-  /**
-   * Returns an `AsyncReducer` that remembers the last input value for which the given `pred` function returns true.
-   * @param pred - a function taking an input value and its index, and returning true if the value should be remembered
-   * @param otherwise - (default: undefined) a fallback value to output if no input value yet has satisfied the given predicate
-   * @typeparam T - the input value type
-   * @typeparam O - the fallback value type
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range({ amount: 10 })).reduce(AsyncReducer.lastWhere(async v => v > 5)))
-   * // => 9
-   * ```
-   */
-  export const lastWhere: {
-    <T>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options?: { negate?: boolean }
-    ): AsyncReducer<T, T | undefined>;
-    <T, O>(
-      pred: (value: T, index: number) => MaybePromise<boolean>,
-      options: { negate?: boolean; otherwise: AsyncOptLazy<O> }
-    ): AsyncReducer<T, T | O>;
-  } = <T, O>(
-    pred: (value: T, index: number) => MaybePromise<boolean>,
-    options: { negate?: boolean; otherwise?: AsyncOptLazy<O> } = {}
-  ) => {
-    const { negate = false, otherwise } = options;
-    const token = Symbol();
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
-      async (state, next, i): Promise<T | typeof token> => {
-        if ((await pred(next, i)) !== negate) return next;
-        return state;
-      },
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
+      (state, index): MaybePromise<T | O> =>
+        index <= 0 ? AsyncOptLazy.toMaybePromise(otherwise!) : state!
     );
   };
 
@@ -1146,144 +1128,92 @@ export namespace AsyncReducer {
     <T>(): AsyncReducer<T, T | undefined>;
     <T, O>(otherwise: AsyncOptLazy<O>): AsyncReducer<T, T | O>;
   } = <T, O>(otherwise?: AsyncOptLazy<O>): AsyncReducer<T, T | O> => {
-    const token = Symbol();
-
-    return create<T, T | O, T | typeof token>(
-      () => token,
+    return create<T, T | O, T | undefined>(
+      () => undefined,
       (_, next): T => next,
-      (state): MaybePromise<T | O> =>
-        token === state ? AsyncOptLazy.toMaybePromise(otherwise!) : state
+      (state, index): MaybePromise<T | O> =>
+        index <= 0 ? AsyncOptLazy.toMaybePromise(otherwise!) : state!
     );
   };
 
-  /**
-   * Returns a `Reducer` that ouputs false as long as no input value satisfies given `pred`, true otherwise.
-   * @typeparam T - the element type
-   * @param pred - a function taking an input value and its index, and returning true if the value satisfies the predicate
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range{ amount: 10 })).reduce(AsyncReducer.some(async v => v > 5))
-   * // => true
-   * ```
-   */
+  export const single: {
+    <T>(): AsyncReducer<T, T | undefined>;
+    <T, O>(otherwise: AsyncOptLazy<O>): AsyncReducer<T, T | O>;
+  } = <T, O>(otherwise?: AsyncOptLazy<O>): AsyncReducer<T, T | O> => {
+    return create<T, T | O, T | undefined>(
+      () => undefined,
+      (state, next, index, halt): T => {
+        if (index > 1) {
+          halt();
+        }
+        return next;
+      },
+      (state, index): MaybePromise<T | O> =>
+        index !== 1 ? AsyncOptLazy.toMaybePromise(otherwise!) : state!
+    );
+  };
+
   export function some<T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: { negate?: boolean } = {}
   ): AsyncReducer<T, boolean> {
-    const { negate = false } = options;
-
-    return createOutput<T, boolean>(
-      () => false,
-      async (state, next, i, halt): Promise<boolean> => {
-        if (state) return state;
-        const satisfies = (await pred(next, i)) !== negate;
-
-        if (satisfies) {
-          halt();
-        }
-
-        return satisfies;
-      }
-    );
+    return nonEmpty.filterInput(pred, options);
   }
 
-  /**
-   * Returns an `AsyncReducer` that ouputs true as long as all input values satisfy the given `pred`, false otherwise.
-   * @typeparam T - the element type
-   * @param pred - a function taking an input value and its index, and returning true if the value satisfies the predicate
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range{ amount: 10 })).reduce(AsyncReducer.every(async v => v < 5))
-   * // => false
-   * ```
-   */
   export function every<T>(
-    pred: (value: T, index: number) => MaybePromise<boolean>,
+    pred: (value: T, index: number) => boolean,
     options: { negate?: boolean } = {}
   ): AsyncReducer<T, boolean> {
     const { negate = false } = options;
 
-    return createOutput<T, boolean>(
-      () => true,
-      async (state, next, i, halt): Promise<boolean> => {
-        if (!state) return state;
-
-        const satisfies = (await pred(next, i)) !== negate;
-
-        if (!satisfies) {
-          halt();
-        }
-
-        return satisfies;
-      }
-    );
+    return isEmpty.filterInput(pred, { negate: !negate });
   }
 
-  /**
-   * Returns an `AsyncReducer` that outputs false as long as the given `elem` has not been encountered in the input values, true otherwise.
-   * @typeparam T - the element type
-   * @param elem - the element to search for
-   * @param eq - (optional) a comparison function that returns true if te two given input values are considered equal
-   * @example
-   * ```ts
-   * await AsyncStream.from(Stream.range({ amount: 10 })).reduce(AsyncReducer.contains(5)))
-   * // => true
-   * ```
-   */
-  export function contains<T>(
-    elem: T,
+  export function equals<T>(
+    other: AsyncStreamSource<T>,
     options: { eq?: Eq<T>; negate?: boolean } = {}
   ): AsyncReducer<T, boolean> {
-    const { eq = Object.is, negate = false } = options;
+    const { eq = Eq.objectIs, negate = false } = options;
 
-    return createOutput<T, boolean>(
-      () => false,
-      (state, next, _, halt): boolean => {
-        if (state) return state;
-        const satisfies = eq(next, elem) !== negate;
+    const sliceStream = fromAsyncStreamSource(other);
+    const done = Symbol();
 
-        if (satisfies) {
+    return AsyncReducer.create<
+      T,
+      boolean,
+      { iter: AsyncFastIterator<T>; nextSeq: T | typeof done; result: boolean }
+    >(
+      async () => {
+        const iter = sliceStream[Symbol.asyncIterator]();
+
+        const nextSeq = await iter.fastNext(done);
+
+        return { iter, nextSeq, result: false };
+      },
+      async (state, next, _, halt) => {
+        if (done === state.nextSeq) {
           halt();
+          state.result = false;
+          return state;
         }
 
-        return satisfies;
-      }
+        if (eq(next, state.nextSeq) === negate) {
+          halt();
+          state.result = false;
+          return state;
+        }
+
+        state.nextSeq = await state.iter.fastNext(done);
+
+        if (done === state.nextSeq) {
+          state.result = true;
+        }
+
+        return state;
+      },
+      (state, index, halted) => !halted && done === state.nextSeq
     );
   }
-
-  /**
-   * Returns an `AsyncReducer` that takes boolean values and outputs true if all input values are true, and false otherwise.
-   * @example
-   * ```ts
-   * await AsyncStream.of(true, false, true)).reduce(AsyncReducer.and))
-   * // => false
-   * ```
-   */
-  export const and = createMono(
-    () => true,
-    (state, next, _, halt): boolean => {
-      if (!state) return state;
-      if (!next) halt();
-      return next;
-    }
-  );
-
-  /**
-   * Returns an `AsyncReducer` that takes boolean values and outputs true if one or more input values are true, and false otherwise.
-   * @example
-   * ```ts
-   * await AsyncStream.of(true, false, true)).reduce(AsyncReducer.or))
-   * // => true
-   * ```
-   */
-  export const or = createMono(
-    () => false,
-    (state, next, _, halt): boolean => {
-      if (state) return state;
-      if (next) halt();
-      return next;
-    }
-  );
 
   /**
    * Returns an `AsyncReducer` that outputs true if no input values are received, false otherwise.
@@ -1293,7 +1223,7 @@ export namespace AsyncReducer {
    * // => false
    * ```
    */
-  export const isEmpty = createOutput<never, boolean>(
+  export const isEmpty = createOutput<any, boolean>(
     () => true,
     (_, __, ___, halt): false => {
       halt();
@@ -1309,7 +1239,7 @@ export namespace AsyncReducer {
    * // => true
    * ```
    */
-  export const nonEmpty = createOutput<never, boolean>(
+  export const nonEmpty = createOutput<any, boolean>(
     () => false,
     (_, __, ___, halt): true => {
       halt();
@@ -1317,117 +1247,293 @@ export namespace AsyncReducer {
     }
   );
 
-  /**
-   * Returns an `AsyncReducer` that collects received input values in an array, and returns a copy of that array as an output value when requested.
-   * @typeparam T - the element type
-   * @example
-   * ```ts
-   * await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.toArray()))
-   * // => [1, 2, 3]
-   * ```
-   */
-  export function toArray<T>(
-    options: { reversed?: boolean } = {}
-  ): AsyncReducer<T, T[]> {
-    const { reversed = false } = options;
+  export function startsWithSlice<T>(
+    slice: AsyncStreamSource<T>,
+    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+  ): AsyncReducer<T, boolean> {
+    const sliceStream = AsyncStreamConstructorsImpl.from(slice);
+    const done = Symbol();
+    const { eq = Eq.objectIs, amount = 1 } = options;
 
-    return create(
-      (): T[] => [],
-      (state, next): T[] => {
-        if (reversed) state.unshift(next);
-        else state.push(next);
+    return AsyncReducer.create<
+      T,
+      boolean,
+      {
+        sliceIter: AsyncFastIterator<T>;
+        sliceValue: T | typeof done;
+        remain: number;
+      }
+    >(
+      async (initHalt) => {
+        const sliceIter = sliceStream[Symbol.asyncIterator]();
+        const sliceValue = await sliceIter.fastNext(done);
+
+        if (done === sliceValue || amount <= 0) {
+          initHalt();
+          return { sliceIter, sliceValue, remain: 0 };
+        }
+
+        return {
+          sliceIter,
+          sliceValue: sliceValue,
+          remain: amount,
+        };
+      },
+      async (state, next, _, halt) => {
+        if (done === state.sliceValue) {
+          RimbuError.throwInvalidStateError();
+        }
+
+        if (eq(next, state.sliceValue)) {
+          state.sliceValue = await state.sliceIter.fastNext(done);
+
+          if (done === state.sliceValue) {
+            state.remain--;
+            if (state.remain <= 0) {
+              halt();
+            } else {
+              state.sliceIter = sliceStream[Symbol.asyncIterator]();
+              state.sliceValue = await state.sliceIter.fastNext(done);
+            }
+          }
+        } else {
+          halt();
+        }
 
         return state;
       },
-      (state): T[] => state.slice()
+      (state) => state.remain <= 0
     );
   }
 
-  /**
-   * Returns a `AsyncReducer` that collects received input tuples into a mutable JS Map, and returns
-   * a copy of that map when output is requested.
-   * @typeparam K - the map key type
-   * @typeparam V - the map value type
-   * @example
-   * ```ts
-   * await AsyncStream.of([1, 'a'], [2, 'b']).reduce(AsyncReducer.toJSMap()))
-   * // Map { 1 => 'a', 2 => 'b' }
-   * ```
-   */
-  export function toJSMap<K, V>(): AsyncReducer<[K, V], Map<K, V>> {
-    return create(
-      (): Map<K, V> => new Map(),
-      (state, next): Map<K, V> => {
-        state.set(next[0], next[1]);
+  export function endsWithSlice<T>(
+    slice: AsyncStreamSource<T>,
+    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+  ): AsyncReducer<T, boolean> {
+    const sliceStream = AsyncStreamConstructorsImpl.from(slice);
+    const done = Symbol();
+
+    const newReducerSpec = AsyncReducer.startsWithSlice(slice, options);
+
+    return AsyncReducer.create<
+      T,
+      boolean,
+      Set<AsyncReducer.Instance<T, boolean>>
+    >(
+      async (initHalt) => {
+        const sliceIter = sliceStream[Symbol.asyncIterator]();
+        const sliceValue = await sliceIter.fastNext(done);
+
+        if (done === sliceValue) {
+          initHalt();
+        }
+
+        return new Set([await newReducerSpec.compile()]);
+      },
+      async (state, nextValue) => {
+        for (const instance of state) {
+          if (instance.halted) {
+            state.delete(instance);
+          } else {
+            instance.next(nextValue);
+          }
+        }
+
+        const newReducerInstance = await newReducerSpec.compile();
+        await newReducerInstance.next(nextValue);
+
+        state.add(newReducerInstance);
+
         return state;
       },
-      (s): Map<K, V> => new Map(s)
+      (state) =>
+        state.size === 0 ||
+        AsyncStreamConstructorsImpl.from(state).some((instance) =>
+          instance.getOutput()
+        )
     );
   }
 
-  /**
-   * Returns an `AsyncReducer` that collects received input values into a mutable JS Set, and returns
-   * a copy of that map when output is requested.
-   * @typeparam T - the element type
-   * @example
-   * ```ts
-   * await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.toJSSet()))
-   * // Set {1, 2, 3}
-   * ```
-   */
-  export function toJSSet<T>(): AsyncReducer<T, Set<T>> {
-    return create(
-      (): Set<T> => new Set<T>(),
-      (state, next): Set<T> => {
-        state.add(next);
-        return state;
-      },
-      (s): Set<T> => new Set(s)
+  export function containsSlice<T>(
+    slice: AsyncStreamSource<T>,
+    options: { eq?: Eq<T> | undefined; amount?: number } = {}
+  ): AsyncReducer<T, boolean> {
+    const { eq, amount = 1 } = options;
+
+    return endsWithSlice(slice, { eq }).pipe(
+      Reducer.contains(true, { amount })
     );
   }
 
-  /**
-   * Returns an `AsyncReducer` that collects 2-tuples containing keys and values into a plain JS object, and
-   * returns a copy of that object when output is requested.
-   * @typeparam K - the result object key type
-   * @typeparam V - the result object value type
-   * @example
-   * ```ts
-   * await AsyncStream.of(['a', 1], ['b', true]).reduce(AsyncReducer.toJSObject()))
-   * // { a: 1, b: true }
-   * ```
-   */
-  export function toJSObject<
-    K extends string | number | symbol,
-    V
-  >(): AsyncReducer<[K, V], Record<K, V>> {
-    return create(
-      () => ({} as Record<K, V>),
-      (state, entry) => {
-        state[entry[0]] = entry[1];
+  export const partition: {
+    <T, T2 extends T, RT, RF = RT>(
+      pred: (value: T, index: number) => value is T2,
+      options: {
+        collectorTrue: AsyncReducer.Accept<T2, RT>;
+        collectorFalse: AsyncReducer.Accept<Exclude<T, T2>, RF>;
+      }
+    ): AsyncReducer<T, [true: RT, false: RF]>;
+    <T, T2 extends T>(
+      pred: (value: T, index: number) => value is T2,
+      options?: {
+        collectorTrue?: undefined;
+        collectorFalse?: undefined;
+      }
+    ): AsyncReducer<T, [true: T2[], false: Exclude<T, T2>[]]>;
+    <T, RT, RF = RT>(
+      pred: (value: T, index: number) => MaybePromise<boolean>,
+      options: {
+        collectorTrue: AsyncReducer.Accept<T, RT>;
+        collectorFalse: AsyncReducer.Accept<T, RF>;
+      }
+    ): AsyncReducer<T, [true: RT, false: RF]>;
+    <T>(
+      pred: (value: T, index: number) => MaybePromise<boolean>,
+      options?: {
+        collectorTrue?: undefined;
+        collectorFalse?: undefined;
+      }
+    ): AsyncReducer<T, [true: T[], false: T[]]>;
+  } = <T, RT, RF = RT>(
+    pred: (value: T, index: number) => MaybePromise<boolean>,
+    options: {
+      collectorTrue?: any;
+      collectorFalse?: any;
+    } = {}
+  ): AsyncReducer<T, [true: RT, false: RF]> => {
+    const {
+      collectorTrue = Reducer.toArray() as AsyncReducer.Accept<T, RT>,
+      collectorFalse = Reducer.toArray() as AsyncReducer.Accept<T, RF>,
+    } = options;
+
+    return AsyncReducer.create(
+      () =>
+        Promise.all([
+          AsyncReducer.from(collectorTrue).compile(),
+          AsyncReducer.from(collectorFalse).compile(),
+        ]),
+      async (state, value, index) => {
+        const instanceIndex = (await pred(value, index)) ? 0 : 1;
+
+        await state[instanceIndex].next(value);
+
         return state;
       },
-      (s) => ({ ...s })
+      (state) =>
+        Promise.all(
+          Stream.from(state).mapPure((v) => v.getOutput())
+        ) as Promise<[RT, RF]>
     );
-  }
+  };
+
+  export const groupBy: {
+    <T, K, R>(
+      valueToKey: (value: T, index: number) => MaybePromise<K>,
+      options: {
+        collector: AsyncReducer.Accept<[K, T], R>;
+      }
+    ): AsyncReducer<T, R>;
+    <T, K>(
+      valueToKey: (value: T, index: number) => MaybePromise<K>,
+      options?: {
+        collector?: undefined;
+      }
+    ): AsyncReducer<T, Map<K, T[]>>;
+  } = <T, K, R>(
+    valueToKey: (value: T, index: number) => MaybePromise<K>,
+    options: {
+      collector?: AsyncReducer.Accept<[K, T], R> | undefined;
+    } = {}
+  ): AsyncReducer<T, R> => {
+    const {
+      collector = Reducer.toJSMultiMap() as AsyncReducer.Accept<[K, T], R>,
+    } = options;
+
+    return AsyncReducer.create(
+      () => AsyncReducer.from(collector).compile(),
+      async (state, value, index) => {
+        const key = await valueToKey(value, index);
+        await state.next([key, value]);
+        return state;
+      },
+      (state) => state.getOutput()
+    );
+  };
+
+  export const combineFirstDone: {
+    <T, R, O>(
+      reducers: AsyncReducer.Accept<T, R>[],
+      otherwise: AsyncOptLazy<O>
+    ): AsyncReducer<T, R | O>;
+    <T, R>(reducers: AsyncReducer.Accept<T, R>[]): AsyncReducer<
+      T,
+      R | undefined
+    >;
+  } = <T, R, O>(
+    reducers: AsyncReducer.Accept<T, R>[],
+    otherwise?: AsyncOptLazy<O>
+  ) => {
+    return AsyncReducer.create<
+      T,
+      R | O,
+      {
+        instances: AsyncReducer.Instance<T, R>[];
+        doneInstance: AsyncReducer.Instance<T, R> | undefined;
+      }
+    >(
+      async (initHalt) => {
+        const instances = await Promise.all(
+          Stream.from(reducers).mapPure((reducer) =>
+            AsyncReducer.from(reducer).compile()
+          )
+        );
+        const doneInstance = instances.find((instance) => instance.halted);
+
+        if (undefined !== doneInstance) {
+          initHalt();
+        }
+
+        return { instances, doneInstance };
+      },
+      async (state, next, _, halt) => {
+        for (const instance of state.instances) {
+          await instance.next(next);
+
+          if (instance.halted) {
+            state.doneInstance = instance;
+            halt();
+            return state;
+          }
+        }
+
+        return state;
+      },
+      (state) =>
+        state.doneInstance === undefined
+          ? AsyncOptLazy.toMaybePromise(otherwise!)
+          : state.doneInstance.getOutput()
+    );
+  };
 
   export type CombineShape<T = unknown> =
-    | AsyncReducer<T, unknown>
-    | CombineShape<T>[]
-    | { [key: string]: CombineShape<T> };
+    | AsyncReducer.Accept<T, unknown>
+    | AsyncReducer.CombineShape<T>[]
+    | { [key: string]: AsyncReducer.CombineShape<T> };
 
-  export type CombineResult<S extends CombineShape> =
-    /* tuple */ S extends readonly CombineShape[]
+  export type CombineResult<S extends AsyncReducer.CombineShape<any>> =
+    /* tuple */ S extends readonly AsyncReducer.CombineShape[]
       ? /* is array? */ 0 extends S['length']
         ? /* no support for arrays */ never
         : /* only tuples */ {
-            [K in keyof S]: S[K] extends CombineShape
-              ? CombineResult<S[K]>
+            [K in keyof S]: S[K] extends AsyncReducer.CombineShape
+              ? AsyncReducer.CombineResult<S[K]>
               : never;
           }
-      : /* plain object */ S extends { [key: string]: CombineShape }
-      ? { [K in keyof S]: CombineResult<S[K]> }
-      : /* simple reducer */ S extends AsyncReducer<unknown, infer R>
+      : /* plain object */ S extends {
+          [key: string]: AsyncReducer.CombineShape;
+        }
+      ? { [K in keyof S]: AsyncReducer.CombineResult<S[K]> }
+      : /* simple reducer */ S extends AsyncReducer.Accept<unknown, infer R>
       ? R
       : never;
 
@@ -1440,6 +1546,18 @@ export namespace AsyncReducer {
   export class ReducerHaltedError extends ErrBase.CustomError {
     constructor() {
       super('A halted reducer cannot receive more values');
+    }
+  }
+
+  export class ReducerClosedError extends ErrBase.CustomError {
+    constructor() {
+      super('A closed async reducer cannot perform more actions');
+    }
+  }
+
+  export class ReducerNotInitializedError extends ErrBase.CustomError {
+    constructor() {
+      super('The async reducer instance was not yet initialized');
     }
   }
 
@@ -1461,10 +1579,13 @@ export namespace AsyncReducer {
     if (shape instanceof AsyncReducer.Base) {
       return shape as any;
     }
+    if (shape instanceof Reducer.Base) {
+      return AsyncReducer.from(shape) as any;
+    }
 
     if (Array.isArray(shape)) {
       return combineArr(
-        ...(shape.map((item) => AsyncReducer.combine(item)) as any)
+        ...(shape.map((item) => AsyncReducer.combine(item as any)) as any)
       ) as any;
     }
 

--- a/packages/stream/src/async/async-streamable.mts
+++ b/packages/stream/src/async/async-streamable.mts
@@ -1,11 +1,25 @@
 import type { AsyncStream } from '@rimbu/stream/async';
 
+/**
+ * Represents an object that can produce an asynchronous stream of values.
+ * @typeparam T - the type of elements in the stream
+ */
 export interface AsyncStreamable<T> {
+  /**
+   * Returns an asynchronous stream of values.
+   */
   asyncStream(): AsyncStream<T>;
 }
 
 export namespace AsyncStreamable {
+  /**
+   * Represents a non-empty object that can produce an asynchronous stream of values.
+   * @typeparam T - the type of elements in the stream
+   */
   export interface NonEmpty<T> {
+    /**
+     * Returns an asynchronous stream of values.
+     */
     asyncStream(): AsyncStream.NonEmpty<T>;
   }
 }

--- a/packages/stream/src/async/async-transformer.mts
+++ b/packages/stream/src/async/async-transformer.mts
@@ -1,4 +1,10 @@
-import { Eq } from '@rimbu/common';
+import {
+  Eq,
+  type AsyncCollectFun,
+  type MaybePromise,
+  CollectFun,
+} from '@rimbu/common';
+import { Reducer, Stream, type Transformer } from '@rimbu/stream';
 import {
   AsyncReducer,
   AsyncStream,
@@ -13,6 +19,11 @@ import {
 export type AsyncTransformer<T, R = T> = AsyncReducer<T, AsyncStreamSource<R>>;
 
 export namespace AsyncTransformer {
+  export type Accept<T, R> = AsyncTransformer<T, R> | Transformer<T, R>;
+  export type AcceptNonEmpty<T, R> =
+    | AsyncTransformer.NonEmpty<T, R>
+    | Transformer.NonEmpty<T, R>;
+
   /**
    * An AsyncReducer that produces instances `AsyncStreamSource.NonEmpty`.
    * @typeparam T - the input element type
@@ -22,6 +33,12 @@ export namespace AsyncTransformer {
     T,
     AsyncStreamSource.NonEmpty<R>
   >;
+
+  export function from<T, R>(
+    transformer: AsyncTransformer.Accept<T, R>
+  ): AsyncTransformer<T, R> {
+    return AsyncReducer.from(transformer);
+  }
 
   /**
    * Returns an async transformer that produces windows/collections of `windowSize` size, each
@@ -45,21 +62,24 @@ export namespace AsyncTransformer {
     <T, R>(
       windowSize: number,
       options: {
-        skipAmount?: number;
-        collector: AsyncReducer<T, R>;
+        skipAmount?: number | undefined;
+        collector: AsyncReducer.Accept<T, R>;
       }
     ): AsyncTransformer<T, R>;
     <T>(
       windowSize: number,
-      options?: { skipAmount?: number }
+      options?: { skipAmount?: number | undefined; collector?: undefined }
     ): AsyncTransformer<T, T[]>;
   } = <T, R>(
     windowSize: number,
-    options: { skipAmount?: number; collector?: AsyncReducer<T, R> } = {}
+    options: {
+      skipAmount?: number | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
+    } = {}
   ) => {
     const {
       skipAmount = windowSize,
-      collector = AsyncReducer.toArray() as AsyncReducer<T, R>,
+      collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
     } = options;
 
     return AsyncReducer.create<
@@ -78,16 +98,18 @@ export namespace AsyncTransformer {
         }
 
         if (index % skipAmount === 0) {
-          const newInstance = collector.compile();
-
+          const newInstance = await AsyncReducer.from(collector).compile();
           await newInstance.next(elem);
-
           state.add(newInstance);
         }
 
         return state;
       },
-      async (state) => {
+      async (state, _, halted) => {
+        if (halted) {
+          return AsyncStream.empty<R>();
+        }
+
         return AsyncStream.from(state).collect((instance, _, skip) =>
           instance.index === windowSize ? instance.getOutput() : skip
         );
@@ -95,50 +117,244 @@ export namespace AsyncTransformer {
     );
   };
 
-  /**
-   * Returns an async transformer that returns only those elements from the input that are different to previous element
-   * according to the optionally given `eq` function.
-   * @param options - (optional) object specifying the following properties<br/>
-   * - eq: (default: `Eq.objectIs`) the `Eq` instance to use to test equality of elements<br/>
-   * - negate: (default: false) when true will negate the given predicate
-   * @example
-   * ```ts
-   * await AsyncStream.of(1, 1, 2, 3, 2, 2)
-   *   .transform(AsyncTransformer.distinctPrevious())
-   *   .toArray()
-   * // => [1, 2, 3, 2]
-   * ```
-   */
-  export function distinctPrevious<T>(
-    options: {
-      eq?: Eq<T>;
-      negate?: boolean;
-    } = {}
+  export function flatMap<T, T2>(
+    flatMapFun: (
+      value: T,
+      index: number,
+      halt: () => void
+    ) => MaybePromise<AsyncStreamSource<T2>>
+  ): AsyncTransformer<T, T2> {
+    return AsyncReducer.createOutput<T, AsyncStreamSource<T2>>(
+      () => AsyncStream.empty<T2>(),
+      (state, next, index, halt) => flatMapFun(next, index, halt),
+      (state, _, halted) => (halted ? AsyncStream.empty() : state)
+    );
+  }
+
+  export function flatZip<T, T2>(
+    flatMapFun: (
+      value: T,
+      index: number,
+      halt: () => void
+    ) => MaybePromise<AsyncStreamSource<T2>>
+  ): AsyncTransformer<T, [T, T2]> {
+    return flatMap(async (value, index, halt) =>
+      AsyncStream.from(await flatMapFun(value, index, halt)).mapPure(
+        (stream) => [value, stream]
+      )
+    );
+  }
+
+  export function filter<T>(
+    pred: (value: T, index: number, halt: () => void) => MaybePromise<boolean>,
+    options: { negate?: boolean | undefined } = {}
   ): AsyncTransformer<T> {
-    const { eq = Eq.objectIs, negate = false } = options;
+    const { negate = false } = options;
+
+    return flatMap(async (value, index, halt) =>
+      (await pred(value, index, halt)) !== negate
+        ? AsyncStream.of(value)
+        : AsyncStream.empty()
+    );
+  }
+
+  export function collect<T, R>(
+    collectFun: AsyncCollectFun<T, R>
+  ): AsyncTransformer<T, R> {
+    return flatMap(async (value, index, halt) => {
+      const result = await collectFun(value, index, CollectFun.Skip, halt);
+
+      return CollectFun.Skip === result
+        ? AsyncStream.empty()
+        : AsyncStream.of(result);
+    });
+  }
+
+  export function intersperse<T>(
+    sep: AsyncStreamSource<T>
+  ): AsyncTransformer<T> {
+    return flatMap((value, index) =>
+      index === 0 ? AsyncStream.of(value) : AsyncStream.from(sep).append(value)
+    );
+  }
+
+  export function indicesWhere<T>(
+    pred: (value: T) => MaybePromise<boolean>,
+    options: { negate?: boolean | undefined } = {}
+  ): AsyncTransformer<T, number> {
+    const { negate = false } = options;
+
+    return flatMap((value, index) =>
+      pred(value) !== negate ? AsyncStream.of(index) : AsyncStream.empty()
+    );
+  }
+
+  export function splitWhere<T, R>(
+    pred: (value: T, index: number) => MaybePromise<boolean>,
+    options: {
+      negate?: boolean | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
+    } = {}
+  ): AsyncTransformer<T, R> {
+    const {
+      negate = false,
+      collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
+    } = options;
 
     return AsyncReducer.create(
-      () => [] as T[],
-      (current, elem) => {
-        current.push(elem);
-
-        if (current.length > 2) {
-          current.shift();
+      async () => ({
+        collection: await AsyncReducer.from(collector).compile(),
+        done: false,
+      }),
+      async (state, nextValue, index) => {
+        if (state.done) {
+          state.done = false;
+          state.collection = await AsyncReducer.from(collector).compile();
         }
 
-        return current;
+        if ((await pred(nextValue, index)) === negate) {
+          await state.collection.next(nextValue);
+        } else {
+          state.done = true;
+        }
+
+        return state;
       },
-      (state) => {
-        if (state.length > 0) {
-          if (state.length === 1) {
-            return AsyncStream.of(state[0]);
+      (state, _, halted) =>
+        state.done !== halted
+          ? AsyncStream.of(state.collection.getOutput())
+          : AsyncStream.empty()
+    );
+  }
+
+  export function splitOn<T, R>(
+    sepElem: T,
+    options: {
+      eq?: Eq<T> | undefined;
+      negate?: boolean | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
+    } = {}
+  ): AsyncTransformer<T, R> {
+    const {
+      eq = Eq.objectIs,
+      negate = false,
+      collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
+    } = options;
+
+    return AsyncReducer.create(
+      async () => ({
+        collection: await AsyncReducer.from(collector).compile(),
+        done: false,
+      }),
+      async (state, nextValue) => {
+        if (state.done) {
+          state.done = false;
+          state.collection = await AsyncReducer.from(collector).compile();
+        }
+
+        if (eq(nextValue, sepElem) === negate) {
+          await state.collection.next(nextValue);
+        } else {
+          state.done = true;
+        }
+
+        return state;
+      },
+      (state, _, halted) =>
+        state.done !== halted
+          ? AsyncStream.of(state.collection.getOutput())
+          : AsyncStream.empty()
+    );
+  }
+
+  export function splitOnSlice<T, R>(
+    sepSlice: AsyncStreamSource<T>,
+    options: {
+      eq?: Eq<T> | undefined;
+      collector?: AsyncReducer.Accept<T, R> | undefined;
+    } = {}
+  ): AsyncTransformer<T, R> {
+    const {
+      eq = Eq.objectIs,
+      collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
+    } = options;
+
+    return AsyncReducer.create<
+      T,
+      AsyncStream<R>,
+      {
+        done: boolean;
+        instances: Map<AsyncReducer.Instance<T, boolean>, number>;
+        buffer: T[];
+        result: AsyncReducer.Instance<T, R>;
+      }
+    >(
+      async () => ({
+        done: false,
+        instances: new Map(),
+        buffer: [],
+        result: await AsyncReducer.from(collector).compile(),
+      }),
+      async (state, nextValue) => {
+        if (state.done) {
+          state.result = await AsyncReducer.from(collector).compile();
+          state.done = false;
+        }
+
+        for (const [instance, startIndex] of state.instances) {
+          await instance.next(nextValue);
+
+          if (instance.halted) {
+            state.instances.delete(instance);
           }
-          if (eq(state[0], state[1]) === negate) {
-            return AsyncStream.of(state[1]);
+
+          if (await instance.getOutput()) {
+            state.done = true;
+            await AsyncStream.from(
+              Stream.fromArray(state.buffer, {
+                range: { end: [startIndex, false] },
+              })
+            ).forEachPure(state.result.next);
+            state.buffer = [];
+            state.instances.clear();
+            return state;
           }
         }
 
-        return AsyncStream.empty();
+        const nextStartsWith = await AsyncReducer.startsWithSlice(sepSlice, {
+          eq,
+        }).compile();
+        await nextStartsWith.next(nextValue);
+
+        if (await nextStartsWith.getOutput()) {
+          state.done = true;
+          await AsyncStream.from(state.buffer).forEachPure(state.result.next);
+          state.buffer = [];
+          state.instances.clear();
+          return state;
+        } else if (!nextStartsWith.halted) {
+          state.instances.set(nextStartsWith, state.buffer.length);
+        }
+
+        if (state.instances.size === 0) {
+          await state.result.next(nextValue);
+        } else {
+          state.buffer.push(nextValue);
+        }
+
+        return state;
+      },
+      async (state, _, halted) => {
+        if (state.done === halted) {
+          return AsyncStream.empty();
+        }
+
+        if (halted) {
+          await AsyncStream.from(state.buffer).forEachPure(state.result.next);
+          state.buffer = [];
+        }
+
+        return AsyncStream.of(state.result.getOutput());
       }
     );
   }

--- a/packages/stream/src/async/interface.mts
+++ b/packages/stream/src/async/interface.mts
@@ -636,7 +636,7 @@ export interface AsyncStream<T>
    */
   containsSlice(
     source: AsyncStreamSource.NonEmpty<T>,
-    options?: { eq?: Eq<T> | undefined }
+    options?: { eq?: Eq<T> | undefined; amount?: number }
   ): Promise<boolean>;
   /**
    * Returns an AsyncStream that contains the elements of this stream up to the first element that does not satisfy given `pred` function.

--- a/packages/stream/src/custom/stream-custom.mts
+++ b/packages/stream/src/custom/stream-custom.mts
@@ -822,20 +822,6 @@ class PrependStream<T> extends StreamBase<T> {
     return compare(result, itemValue) > 0 ? result : itemValue;
   }
 
-  join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): string {
-    return this.source.join({
-      sep,
-      start: `${start}${valueToString(OptLazy(this.item))}`,
-      end,
-      valueToString,
-    });
-  }
-
   toArray(): T[] {
     const result = this.source.toArray();
     result.unshift(OptLazy(this.item));
@@ -910,20 +896,6 @@ class AppendStream<T> extends StreamBase<T> {
     }
 
     return compare(result, itemValue) > 0 ? result : itemValue;
-  }
-
-  join({
-    sep = '',
-    start = '',
-    end = '',
-    valueToString = String,
-  } = {}): string {
-    return this.source.join({
-      sep,
-      start,
-      end: `${valueToString(OptLazy(this.item))}${end}`,
-      valueToString,
-    });
   }
 
   toArray(): T[] {

--- a/packages/stream/src/main/interface.mts
+++ b/packages/stream/src/main/interface.mts
@@ -794,22 +794,22 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
   /**
    * Returns a Stream of collections of Stream elements, where each collection is filled with elements of this Stream up to the next sequence of elements that
    * equal the given `sepSeq` sequence of elements according to the given `eq` function.
-   * @param sepSeq - a sequence of elements that serves as a separator
+   * @param sepSlice - a sequence of elements that serves as a separator
    * @param options - (optional) object specifying the following properties<br/>
    * - eq: (default: `Eq.objectIs`) the `Eq` instance to use to test equality of elements<br/>
    * - collector: (default: `Reducer.toArray()`) the reducer to use to collect the window values
    * @example
    * ```ts
-   * Stream.from('marmot').splitOnSeq('mo').toArray()  // => [['m', 'a', 'r'], ['t']]
+   * Stream.from('marmot').splitOnSlice('mo').toArray()  // => [['m', 'a', 'r'], ['t']]
    * ```
    * @note O(1)
    */
-  splitOnSeq<R, T2 extends T = T>(
-    sepSeq: StreamSource<T2>,
+  splitOnSlice<R, T2 extends T = T>(
+    sepSlice: StreamSource<T2>,
     options: { eq?: Eq<T2>; collector: Reducer<T, R> }
   ): Stream<R>;
-  splitOnSeq(
-    sepSeq: StreamSource<T>,
+  splitOnSlice(
+    sepSlice: StreamSource<T>,
     options?: { eq?: Eq<T>; collector?: undefined }
   ): Stream<T[]>;
   /**

--- a/packages/stream/src/main/interface.mts
+++ b/packages/stream/src/main/interface.mts
@@ -615,7 +615,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    */
   containsSlice(
     source: StreamSource.NonEmpty<T>,
-    options?: { eq?: Eq<T> | undefined }
+    options?: { eq?: Eq<T> | undefined; amount?: number | undefined }
   ): boolean;
   /**
    * Returns a Stream that contains the elements of this Stream up to the first element that does not satisfy given `pred` function.

--- a/packages/stream/src/main/reducer.mts
+++ b/packages/stream/src/main/reducer.mts
@@ -256,7 +256,7 @@ export namespace Reducer {
      */
     sliceInput(from?: number, amount?: number): Reducer<I, O>;
     takeOutput(amount: number): Reducer<I, O>;
-    takeOutputWhile(
+    takeOutputUntil(
       pred: (value: O, index: number) => boolean,
       options?: { negate?: boolean }
     ): Reducer<I, O>;
@@ -486,7 +486,7 @@ export namespace Reducer {
       return create(
         this.init,
         (state, next, index, halt) => {
-          if (index >= amount) {
+          if (index >= amount - 1) {
             halt();
           }
           return this.next(state, next, index, halt);
@@ -495,7 +495,7 @@ export namespace Reducer {
       );
     }
 
-    takeOutputWhile(
+    takeOutputUntil(
       pred: (value: O, index: number) => boolean,
       options: { negate?: boolean } = {}
     ): Reducer<I, O> {
@@ -508,11 +508,11 @@ export namespace Reducer {
 
           const nextOutput = this.stateToResult(nextState, index, false);
 
-          if (pred(nextOutput, index) === negate) {
+          if (pred(nextOutput, index) !== negate) {
             halt();
           }
 
-          return state;
+          return nextState;
         },
         this.stateToResult
       );
@@ -1459,7 +1459,7 @@ export namespace Reducer {
     );
   };
 
-  export const combineFirstDone: {
+  export const race: {
     <T, R, O>(reducers: Reducer<T, R>[], otherwise: OptLazy<O>): Reducer<
       T,
       R | O

--- a/packages/stream/src/main/transformer.mts
+++ b/packages/stream/src/main/transformer.mts
@@ -1,4 +1,4 @@
-import { Eq } from '@rimbu/common';
+import { CollectFun, Eq } from '@rimbu/common';
 
 import { Reducer, Stream, type StreamSource } from '@rimbu/stream';
 
@@ -38,17 +38,20 @@ export namespace Transformer {
     <T, R>(
       windowSize: number,
       options: {
-        skipAmount?: number;
+        skipAmount?: number | undefined;
         collector: Reducer<T, R>;
       }
     ): Transformer<T, R>;
-    <T>(windowSize: number, options?: { skipAmount?: number }): Transformer<
-      T,
-      T[]
-    >;
+    <T>(
+      windowSize: number,
+      options?: { skipAmount?: number | undefined; collector?: undefined }
+    ): Transformer<T, T[]>;
   } = <T, R>(
     windowSize: number,
-    options: { skipAmount?: number; collector?: Reducer<T, R> } = {}
+    options: {
+      skipAmount?: number | undefined;
+      collector?: Reducer<T, R> | undefined;
+    } = {}
   ) => {
     const {
       skipAmount = windowSize,
@@ -76,7 +79,10 @@ export namespace Transformer {
 
         return state;
       },
-      (state) => {
+      (state, _, halted) => {
+        if (halted) {
+          return Stream.empty<R>();
+        }
         return Stream.from(state).collect((instance, _, skip) =>
           instance.index === windowSize ? instance.getOutput() : skip
         );
@@ -96,7 +102,11 @@ export namespace Transformer {
    * // => [1, 2, 3, 2]
    * ```
    */
-  export function distinctPrevious<T>(eq: Eq<T> = Eq.objectIs): Transformer<T> {
+  export function distinctPrevious<T>(
+    options: { eq?: Eq<T>; negate?: boolean } = {}
+  ): Transformer<T> {
+    const { eq = Eq.objectIs, negate = false } = options;
+
     return Reducer.create(
       () => [] as T[],
       (current, elem) => {
@@ -108,17 +118,234 @@ export namespace Transformer {
 
         return current;
       },
-      (state) => {
-        if (state.length > 0) {
+      (state, _, halted) => {
+        if (!halted && state.length > 0) {
           if (state.length === 1) {
             return Stream.of(state[0]);
           }
-          if (!eq(state[0], state[1])) {
+          if (eq(state[0], state[1]) === negate) {
             return Stream.of(state[1]);
           }
         }
 
         return Stream.empty();
+      }
+    );
+  }
+
+  export function filter<T>(
+    pred: (value: T, index: number, halt: () => void) => boolean,
+    options: { negate?: boolean } = {}
+  ): Transformer<T> {
+    const { negate = false } = options;
+
+    return flatMap((value, index, halt) =>
+      pred(value, index, halt) !== negate ? Stream.of(value) : Stream.empty()
+    );
+  }
+
+  export function collect<T, R>(
+    collectFun: CollectFun<T, R>
+  ): Transformer<T, R> {
+    return flatMap((value, index, halt) => {
+      const result = collectFun(value, index, CollectFun.Skip, halt);
+      return CollectFun.Skip === result ? Stream.empty() : Stream.of(result);
+    });
+  }
+
+  export function flatMap<T, T2>(
+    flatMapFun: (value: T, index: number, halt: () => void) => StreamSource<T2>
+  ): Transformer<T, T2> {
+    return Reducer.createOutput<T, StreamSource<T2>>(
+      () => Stream.empty<T2>(),
+      (state, next, index, halt) => flatMapFun(next, index, halt),
+      (state, _, halted) => (halted ? Stream.empty() : state)
+    );
+  }
+
+  export function flatZip<T, T2>(
+    flatMapFun: (value: T, index: number, halt: () => void) => StreamSource<T2>
+  ): Transformer<T, [T, T2]> {
+    return flatMap((value, index, halt) =>
+      Stream.from(flatMapFun(value, index, halt)).map((stream) => [
+        value,
+        stream,
+      ])
+    );
+  }
+
+  export function intersperse<T>(sep: StreamSource<T>): Transformer<T> {
+    return flatMap((value, index) =>
+      index === 0 ? Stream.of(value) : Stream.from(sep).append(value)
+    );
+  }
+
+  export function indicesWhere<T>(
+    pred: (value: T) => boolean,
+    options: { negate?: boolean } = {}
+  ): Transformer<T, number> {
+    const { negate = false } = options;
+
+    return flatMap((value, index) =>
+      pred(value) !== negate ? Stream.of(index) : Stream.empty()
+    );
+  }
+
+  export function indicesOf<T>(
+    searchValue: T,
+    options: { eq?: Eq<T>; negate?: boolean } = {}
+  ): Transformer<T, number> {
+    const { eq = Eq.objectIs, negate = false } = options;
+
+    return flatMap((value, index) =>
+      eq(value, searchValue) !== negate ? Stream.of(index) : Stream.empty()
+    );
+  }
+
+  export function splitWhere<T, R>(
+    pred: (value: T, index: number) => boolean,
+    options: { negate?: boolean; collector?: Reducer<T, R> } = {}
+  ): Transformer<T, R> {
+    const { negate = false, collector = Reducer.toArray() as Reducer<T, R> } =
+      options;
+
+    return Reducer.create(
+      () => ({ collection: collector.compile(), done: false }),
+      (state, nextValue, index) => {
+        if (state.done) {
+          state.done = false;
+          state.collection = collector.compile();
+        }
+
+        if (pred(nextValue, index) !== negate) {
+          state.collection.next(nextValue);
+        } else {
+          state.done = true;
+        }
+
+        return state;
+      },
+      (state) =>
+        state.done ? Stream.of(state.collection.getOutput()) : Stream.empty()
+    );
+  }
+
+  export function splitOn<T, R>(
+    sepElem: T,
+    options: {
+      eq?: Eq<T>;
+      negate?: boolean;
+      collector?: Reducer<T, R> | undefined;
+    } = {}
+  ): Transformer<T, R> {
+    const {
+      eq = Eq.objectIs,
+      negate = false,
+      collector = Reducer.toArray() as Reducer<T, R>,
+    } = options;
+
+    return Reducer.create(
+      () => ({ collection: collector.compile(), done: false }),
+      (state, nextValue) => {
+        if (state.done) {
+          state.done = false;
+          state.collection = collector.compile();
+        }
+
+        if (eq(nextValue, sepElem) === negate) {
+          state.collection.next(nextValue);
+        } else {
+          state.done = true;
+        }
+
+        return state;
+      },
+      (state, _, halted) =>
+        state.done !== halted
+          ? Stream.of(state.collection.getOutput())
+          : Stream.empty()
+    );
+  }
+
+  export function splitOnSlice<T, R>(
+    sepSlice: StreamSource<T>,
+    options: { eq?: Eq<T>; collector?: Reducer<T, R> | undefined } = {}
+  ): Transformer<T, R> {
+    const { eq = Eq.objectIs, collector = Reducer.toArray() as Reducer<T, R> } =
+      options;
+
+    return Reducer.create<
+      T,
+      Stream<R>,
+      {
+        done: boolean;
+        instances: Map<Reducer.Instance<T, boolean>, number>;
+        buffer: T[];
+        result: Reducer.Instance<T, R>;
+      }
+    >(
+      () => ({
+        done: false,
+        instances: new Map(),
+        buffer: [],
+        result: collector.compile(),
+      }),
+      (state, nextValue) => {
+        if (state.done) {
+          state.result = collector.compile();
+          state.done = false;
+        }
+
+        for (const [instance, startIndex] of state.instances) {
+          instance.next(nextValue);
+
+          if (instance.halted) {
+            state.instances.delete(instance);
+          }
+
+          if (instance.getOutput()) {
+            state.done = true;
+            Stream.fromArray(state.buffer, {
+              range: { end: [startIndex, false] },
+            }).forEachPure(state.result.next);
+            state.buffer = [];
+            state.instances.clear();
+            return state;
+          }
+        }
+
+        const nextStartsWith = Reducer.startsWithSlice(sepSlice).compile();
+        nextStartsWith.next(nextValue);
+
+        if (nextStartsWith.getOutput()) {
+          state.done = true;
+          Stream.fromArray(state.buffer).forEachPure(state.result.next);
+          state.buffer = [];
+          state.instances.clear();
+          return state;
+        } else if (!nextStartsWith.halted) {
+          state.instances.set(nextStartsWith, state.buffer.length);
+        }
+
+        if (state.instances.size === 0) {
+          state.result.next(nextValue);
+        } else {
+          state.buffer.push(nextValue);
+        }
+
+        return state;
+      },
+      (state, _, halted) => {
+        if (state.done === halted) {
+          return Stream.empty();
+        }
+
+        if (halted) {
+          Stream.fromArray(state.buffer).forEachPure(state.result.next);
+          state.buffer = [];
+        }
+
+        return Stream.of(state.result.getOutput());
       }
     );
   }

--- a/packages/stream/test-d/async-reducer.test-d.mts
+++ b/packages/stream/test-d/async-reducer.test-d.mts
@@ -1,0 +1,167 @@
+import { AsyncStream, Reducer } from '@rimbu/stream';
+import { expectAssignable, expectType } from 'tsd';
+
+import { AsyncReducer } from '../src/main/index.mjs';
+
+// AsyncReducer.combine shapes
+expectType<AsyncReducer<number, [number[], number]>>(
+  AsyncReducer.combine([Reducer.toArray<number>(), Reducer.sum])
+);
+
+expectType<Promise<[number[], number]>>(
+  AsyncStream.of(1, 2).reduce(
+    AsyncReducer.combine([Reducer.toArray<number>(), Reducer.sum])
+  )
+);
+
+expectAssignable<AsyncReducer<number, { a: number[]; s: number }>>(
+  AsyncReducer.combine({
+    a: Reducer.toArray<number>(),
+    s: Reducer.sum,
+  })
+);
+
+expectAssignable<Promise<{ a: number[]; s: number }>>(
+  AsyncStream.of(1, 2).reduce(
+    AsyncReducer.combine({
+      a: Reducer.toArray<number>(),
+      s: Reducer.sum,
+    })
+  )
+);
+
+// AsyncReducer.combineFirstDone
+expectType<AsyncReducer<number, number | undefined>>(
+  AsyncReducer.combineFirstDone([Reducer.sum, Reducer.product])
+);
+
+expectType<AsyncReducer<number, number>>(
+  AsyncReducer.combineFirstDone([Reducer.sum, Reducer.product], 5)
+);
+
+// AsyncReducer.groupBy
+expectType<AsyncReducer<string, Map<number, string[]>>>(
+  AsyncReducer.groupBy((value: string) => value.length)
+);
+
+expectType<AsyncReducer<string, string>>(
+  AsyncReducer.groupBy((value: string) => value.length, {
+    collector: Reducer.join<[number, string]>(),
+  })
+);
+
+// AsyncReducer.partition
+expectType<AsyncReducer<number, [number[], number[]]>>(
+  AsyncReducer.partition<number>(() => true)
+);
+
+expectType<AsyncReducer<number, [Set<number>, string]>>(
+  AsyncReducer.partition(() => true, {
+    collectorTrue: Reducer.toJSSet<number>(),
+    collectorFalse: Reducer.join<number>(),
+  })
+);
+
+// AsyncReducer methods
+
+// .chain()
+expectType<Promise<number>>(
+  AsyncStream.of(1, 2, 3).reduce(
+    AsyncReducer.first<number>().chain(AsyncReducer.min(5))
+  )
+);
+expectType<Promise<number[]>>(
+  AsyncStream.of(1, 2, 3).reduce(
+    AsyncReducer.first<number>().chain(Reducer.sum, Reducer.toArray<number>())
+  )
+);
+
+// .collectInput
+expectType<AsyncReducer<string, number>>(
+  AsyncReducer.max(5).collectInput<string>((v) => v.length)
+);
+
+// .compile
+expectType<Promise<AsyncReducer.Instance<number, number | undefined>>>(
+  AsyncReducer.first<number>().compile()
+);
+
+// .dropInput
+expectType<AsyncReducer<number, number>>(AsyncReducer.min(5).dropInput(5));
+
+// .flatMapInput
+expectType<AsyncReducer<string, number[]>>(
+  AsyncReducer.from(Reducer.toArray<number>()).flatMapInput<string>(() => [
+    1, 2,
+  ])
+);
+
+// .filterInput
+expectType<AsyncReducer<number | string, Array<number | string>>>(
+  AsyncReducer.from(Reducer.toArray<number | string>()).filterInput(() => true)
+);
+expectType<AsyncReducer<number | string, Array<number | string>>>(
+  AsyncReducer.from(Reducer.toArray<number | string>()).filterInput(
+    () => true,
+    { negate: true }
+  )
+);
+
+expectType<AsyncReducer<string, Array<number | string>>>(
+  AsyncReducer.from(Reducer.toArray<number | string>()).filterInput(
+    (v): v is string => true
+  )
+);
+expectType<AsyncReducer<number, Array<number | string>>>(
+  AsyncReducer.from(Reducer.toArray<number | string>()).filterInput(
+    (v): v is string => true,
+    {
+      negate: true,
+    }
+  )
+);
+
+// .takeInput
+expectType<AsyncReducer<number, number[]>>(
+  AsyncReducer.from(Reducer.toArray<number>()).takeInput(5)
+);
+
+// .takeOutput
+expectType<AsyncReducer<number, number[]>>(
+  AsyncReducer.from(Reducer.toArray<number>()).takeOutput(5)
+);
+
+// .takeOutputWhile
+expectType<AsyncReducer<number, number[]>>(
+  AsyncReducer.from(Reducer.toArray<number>()).takeOutputWhile(() => true)
+);
+
+// .mapInput
+expectType<AsyncReducer<string, number[]>>(
+  AsyncReducer.from(Reducer.toArray<number>()).mapInput<string>((v) => v.length)
+);
+
+// .mapOutput
+expectType<AsyncReducer<string, number>>(
+  AsyncReducer.from(Reducer.toArray<string>()).mapOutput((v) => v.length)
+);
+
+// .pipe()
+expectType<Promise<string>>(
+  AsyncStream.of(1, 2, 3).reduce(
+    AsyncReducer.from(Reducer.sum).pipe(Reducer.join<number>())
+  )
+);
+expectType<Promise<boolean>>(
+  AsyncStream.of(1, 2, 3).reduce(
+    AsyncReducer.from(Reducer.sum).pipe(
+      Reducer.toArray<number>(),
+      Reducer.nonEmpty
+    )
+  )
+);
+
+// .sliceInput
+expectType<AsyncReducer<number, number[]>>(
+  AsyncReducer.from(Reducer.toArray<number>()).sliceInput(5, 3)
+);

--- a/packages/stream/test-d/async-reducer.test-d.mts
+++ b/packages/stream/test-d/async-reducer.test-d.mts
@@ -32,11 +32,11 @@ expectAssignable<Promise<{ a: number[]; s: number }>>(
 
 // AsyncReducer.combineFirstDone
 expectType<AsyncReducer<number, number | undefined>>(
-  AsyncReducer.combineFirstDone([Reducer.sum, Reducer.product])
+  AsyncReducer.race([Reducer.sum, Reducer.product])
 );
 
 expectType<AsyncReducer<number, number>>(
-  AsyncReducer.combineFirstDone([Reducer.sum, Reducer.product], 5)
+  AsyncReducer.race([Reducer.sum, Reducer.product], 5)
 );
 
 // AsyncReducer.groupBy
@@ -133,7 +133,7 @@ expectType<AsyncReducer<number, number[]>>(
 
 // .takeOutputWhile
 expectType<AsyncReducer<number, number[]>>(
-  AsyncReducer.from(Reducer.toArray<number>()).takeOutputWhile(() => true)
+  AsyncReducer.from(Reducer.toArray<number>()).takeOutputUntil(() => true)
 );
 
 // .mapInput

--- a/packages/stream/test-d/async-stream.test-d.mts
+++ b/packages/stream/test-d/async-stream.test-d.mts
@@ -14,7 +14,7 @@ import {
   AsyncTransformer,
   type AsyncFastIterator,
 } from '../src/async/index.mjs';
-import type { Stream } from '../src/main/index.mjs';
+import { Reducer, type Stream } from '../src/main/index.mjs';
 
 // Variance
 expectAssignable<AsyncStream<number | string>>(AsyncStream.empty<number>());
@@ -632,15 +632,15 @@ expectType<boolean>(await AsyncStream.of(1).reduce(AsyncReducer.isEmpty));
 expectType<[boolean, number, string]>(
   await AsyncStream.empty<number>().reduce([
     AsyncReducer.isEmpty,
-    AsyncReducer.sum,
-    AsyncReducer.join<number>(),
+    Reducer.sum,
+    Reducer.join<number>(),
   ])
 );
 expectType<[boolean, number, string]>(
   await AsyncStream.of(1).reduce([
     AsyncReducer.isEmpty,
-    AsyncReducer.sum,
-    AsyncReducer.join<number>(),
+    Reducer.sum,
+    Reducer.join<number>(),
   ])
 );
 
@@ -648,15 +648,15 @@ expectType<[boolean, number, string]>(
 expectType<AsyncStream<[boolean, number, string]>>(
   AsyncStream.empty<number>().reduceStream([
     AsyncReducer.isEmpty,
-    AsyncReducer.sum,
-    AsyncReducer.join<number>(),
+    Reducer.sum,
+    Reducer.join<number>(),
   ])
 );
 expectType<AsyncStream<[boolean, number, string]>>(
   AsyncStream.of(1).reduceStream([
     AsyncReducer.isEmpty,
-    AsyncReducer.sum,
-    AsyncReducer.join<number>(),
+    Reducer.sum,
+    Reducer.join<number>(),
   ])
 );
 

--- a/packages/stream/test-d/reducer.test.mts
+++ b/packages/stream/test-d/reducer.test.mts
@@ -22,7 +22,7 @@ expectAssignable<Reducer<number, { a: number[]; s: number }>>(
 expectAssignable<{ a: number[]; s: number }>(
   Stream.of(1, 2).reduce(
     Reducer.combine({
-      a: Reducer.toArray(),
+      a: Reducer.toArray<number>(),
       s: Reducer.sum,
     })
   )
@@ -30,11 +30,11 @@ expectAssignable<{ a: number[]; s: number }>(
 
 // Reducer.combineFirstDone
 expectType<Reducer<number, number | undefined>>(
-  Reducer.combineFirstDone([Reducer.sum, Reducer.product])
+  Reducer.race([Reducer.sum, Reducer.product])
 );
 
 expectType<Reducer<number, number>>(
-  Reducer.combineFirstDone([Reducer.sum, Reducer.product], 5)
+  Reducer.race([Reducer.sum, Reducer.product], 5)
 );
 
 // Reducer.groupBy
@@ -116,7 +116,7 @@ expectType<Reducer<number, number[]>>(Reducer.toArray<number>().takeOutput(5));
 
 // .takeOutputWhile
 expectType<Reducer<number, number[]>>(
-  Reducer.toArray<number>().takeOutputWhile(() => true)
+  Reducer.toArray<number>().takeOutputUntil(() => true)
 );
 
 // .mapInput

--- a/packages/stream/test-d/reducer.test.mts
+++ b/packages/stream/test-d/reducer.test.mts
@@ -3,6 +3,7 @@ import { expectAssignable, expectType } from 'tsd';
 
 import { Reducer } from '../src/main/index.mjs';
 
+// Reducer.combine shapes
 expectType<Reducer<number, [number[], number]>>(
   Reducer.combine([Reducer.toArray(), Reducer.sum])
 );
@@ -27,8 +28,116 @@ expectAssignable<{ a: number[]; s: number }>(
   )
 );
 
-expectType<string>(Stream.of(1, 2, 3).reduce(Reducer.sum.pipe(Reducer.join())));
+// Reducer.combineFirstDone
+expectType<Reducer<number, number | undefined>>(
+  Reducer.combineFirstDone([Reducer.sum, Reducer.product])
+);
 
+expectType<Reducer<number, number>>(
+  Reducer.combineFirstDone([Reducer.sum, Reducer.product], 5)
+);
+
+// Reducer.groupBy
+expectType<Reducer<string, Map<number, string[]>>>(
+  Reducer.groupBy((value: string) => value.length)
+);
+
+expectType<Reducer<string, string>>(
+  Reducer.groupBy((value: string) => value.length, {
+    collector: Reducer.join(),
+  })
+);
+
+// Reducer.toArray
+expectType<Reducer<number, number[]>>(Reducer.toArray<number>());
+
+// Reducer.partition
+expectType<Reducer<number, [number[], number[]]>>(
+  Reducer.partition<number>(() => true)
+);
+
+expectType<Reducer<number, [Set<number>, string]>>(
+  Reducer.partition(() => true, {
+    collectorTrue: Reducer.toJSSet<number>(),
+    collectorFalse: Reducer.join<number>(),
+  })
+);
+
+// Reducer methods
+
+// .chain()
 expectType<number>(
   Stream.of(1, 2, 3).reduce(Reducer.sum.chain(Reducer.product))
+);
+expectType<number[]>(
+  Stream.of(1, 2, 3).reduce(
+    Reducer.sum.chain(Reducer.product, Reducer.toArray())
+  )
+);
+
+// .collectInput
+expectType<Reducer<string, number[]>>(
+  Reducer.toArray<number>().collectInput<string>((v) => v.length)
+);
+
+// .compile
+expectType<Reducer.Instance<number, string>>(Reducer.join<number>().compile());
+
+// .dropInput
+expectType<Reducer<number, number[]>>(Reducer.toArray<number>().dropInput(5));
+
+// .flatMapInput
+expectType<Reducer<string, number[]>>(
+  Reducer.toArray<number>().flatMapInput<string>(() => [1, 2])
+);
+
+// .filterInput
+expectType<Reducer<number | string, Array<number | string>>>(
+  Reducer.toArray<number | string>().filterInput(() => true)
+);
+expectType<Reducer<number | string, Array<number | string>>>(
+  Reducer.toArray<number | string>().filterInput(() => true, { negate: true })
+);
+
+expectType<Reducer<string, Array<number | string>>>(
+  Reducer.toArray<number | string>().filterInput((v): v is string => true)
+);
+expectType<Reducer<number, Array<number | string>>>(
+  Reducer.toArray<number | string>().filterInput((v): v is string => true, {
+    negate: true,
+  })
+);
+
+// .takeInput
+expectType<Reducer<number, number[]>>(Reducer.toArray<number>().takeInput(5));
+
+// .takeOutput
+expectType<Reducer<number, number[]>>(Reducer.toArray<number>().takeOutput(5));
+
+// .takeOutputWhile
+expectType<Reducer<number, number[]>>(
+  Reducer.toArray<number>().takeOutputWhile(() => true)
+);
+
+// .mapInput
+expectType<Reducer<string, number[]>>(
+  Reducer.toArray<number>().mapInput<string>((v) => v.length)
+);
+
+// .mapOutput
+expectType<Reducer<string, number>>(
+  Reducer.toArray<string>().mapOutput((v) => v.length)
+);
+
+// .pipe()
+expectType<string>(Stream.of(1, 2, 3).reduce(Reducer.sum.pipe(Reducer.join())));
+expectType<boolean>(
+  Stream.of(1, 2, 3).reduce(
+    Reducer.sum.pipe(Reducer.toArray(), Reducer.nonEmpty)
+  )
+);
+
+// .sliceInput
+expectType<Reducer<number, number[]>>(
+  Reducer.toArray<number>().sliceInput(5, 3)
 );

--- a/packages/stream/test/async-reducer.test.mts
+++ b/packages/stream/test/async-reducer.test.mts
@@ -1,6 +1,6 @@
 import { Comp, Eq } from '@rimbu/common';
 
-import { AsyncReducer, AsyncStream } from '../src/main/index.mjs';
+import { AsyncReducer, AsyncStream, Reducer } from '../src/main/index.mjs';
 
 describe('AsyncReducer', () => {
   const FB = 'a';
@@ -13,7 +13,7 @@ describe('AsyncReducer', () => {
       async (v) => v + 1
     );
     expect(await r.next(6, 7, 8, () => {})).toBe(6 + 7 + 8);
-    expect(await r.stateToResult(5)).toBe(6);
+    expect(await r.stateToResult(5, 0, false)).toBe(6);
   });
 
   it('createMono', async () => {
@@ -23,7 +23,7 @@ describe('AsyncReducer', () => {
       async (v) => v + 1
     );
     expect(await r.next(6, 7, 8, () => {})).toBe(6 + 7 + 8);
-    expect(await r.stateToResult(5)).toBe(6);
+    expect(await r.stateToResult(5, 0, false)).toBe(6);
   });
 
   it('createOutput', async () => {
@@ -32,23 +32,25 @@ describe('AsyncReducer', () => {
       async (v, n, i) => v + n + i
     );
     expect(await r.next(6, 7, 8, () => {})).toBe(6 + 7 + 8);
-    expect(await r.stateToResult(5)).toBe(5);
+    expect(await r.stateToResult(5, 0, false)).toBe(5);
   });
 
   it('sum', async () => {
     const s = AsyncStream.of(1, 2, 3);
-    expect(await s.reduce(AsyncReducer.sum)).toBe(6);
+    expect(await s.reduce(AsyncReducer.from(Reducer.sum))).toBe(6);
   });
 
   it('product', async () => {
     const s = AsyncStream.of(1, 2, 3);
-    expect(await s.reduce(AsyncReducer.product)).toBe(6);
-    expect(await AsyncStream.of(5, 0, 4).reduce(AsyncReducer.product)).toBe(0);
+    expect(await s.reduce(AsyncReducer.from(Reducer.product))).toBe(6);
+    expect(
+      await AsyncStream.of(5, 0, 4).reduce(AsyncReducer.from(Reducer.product))
+    ).toBe(0);
   });
 
   it('average', async () => {
     const s = AsyncStream.of(1, 2, 3);
-    expect(await s.reduce(AsyncReducer.average)).toBe(2);
+    expect(await s.reduce(AsyncReducer.from(Reducer.average))).toBe(2);
   });
 
   it('minBy', async () => {
@@ -110,97 +112,19 @@ describe('AsyncReducer', () => {
   });
 
   it('join', async () => {
-    expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.join())).toBe(
+    expect(await AsyncStream.of(1, 2, 3).reduce(Reducer.join<number>())).toBe(
       '123'
     );
     expect(
       await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.join({ start: '[', sep: ',', end: ']' })
+        Reducer.join<number>({ start: '[', sep: ',', end: ']' })
       )
     ).toBe('[1,2,3]');
     expect(
       await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.join({ valueToString: (v) => `${v}${v}` })
+        Reducer.join<number>({ valueToString: (v) => `${v}${v}` })
       )
     ).toBe('112233');
-  });
-
-  it('count', async () => {
-    expect(await AsyncStream.empty<number>().reduce(AsyncReducer.count())).toBe(
-      0
-    );
-    expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.count())).toBe(3);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.count((v) => v > 2))
-    ).toBe(1);
-  });
-
-  it('firstWhere', async () => {
-    const s = AsyncStream.of(1, 2, 3);
-    expect(await s.reduce(AsyncReducer.firstWhere(async (v) => v === 2))).toBe(
-      2
-    );
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v === 2, { otherwise: fallback })
-      )
-    ).toBe(2);
-    expect(await s.reduce(AsyncReducer.firstWhere(async (v) => v > 10))).toBe(
-      undefined
-    );
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v > 10, { otherwise: fallback })
-      )
-    ).toBe(FB);
-    expect(await s.reduce(AsyncReducer.firstWhere(async (v) => v < 10))).toBe(
-      1
-    );
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v < 10, { otherwise: fallback })
-      )
-    ).toBe(1);
-
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v !== 2, { negate: true })
-      )
-    ).toBe(2);
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v !== 2, {
-          negate: true,
-          otherwise: fallback,
-        })
-      )
-    ).toBe(2);
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v <= 10, { negate: true })
-      )
-    ).toBe(undefined);
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v <= 10, {
-          negate: true,
-          otherwise: fallback,
-        })
-      )
-    ).toBe(FB);
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v > 10, { negate: true })
-      )
-    ).toBe(1);
-    expect(
-      await s.reduce(
-        AsyncReducer.firstWhere(async (v) => v >= 10, {
-          negate: true,
-          otherwise: fallback,
-        })
-      )
-    ).toBe(1);
   });
 
   it('first', async () => {
@@ -216,72 +140,6 @@ describe('AsyncReducer', () => {
     ).toBe(1);
   });
 
-  it('lastWhere', async () => {
-    const s = AsyncStream.of(1, 2, 3);
-    expect(await s.reduce(AsyncReducer.lastWhere(async (v) => v === 2))).toBe(
-      2
-    );
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v === 2, { otherwise: fallback })
-      )
-    ).toBe(2);
-    expect(await s.reduce(AsyncReducer.lastWhere(async (v) => v > 10))).toBe(
-      undefined
-    );
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v > 10, { otherwise: fallback })
-      )
-    ).toBe(FB);
-    expect(await s.reduce(AsyncReducer.lastWhere(async (v) => v < 10))).toBe(3);
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v < 10, { otherwise: fallback })
-      )
-    ).toBe(3);
-
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v !== 2, { negate: true })
-      )
-    ).toBe(2);
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v !== 2, {
-          negate: true,
-          otherwise: fallback,
-        })
-      )
-    ).toBe(2);
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v <= 10, { negate: true })
-      )
-    ).toBe(undefined);
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v <= 10, {
-          negate: true,
-          otherwise: fallback,
-        })
-      )
-    ).toBe(FB);
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v >= 10, { negate: true })
-      )
-    ).toBe(3);
-    expect(
-      await s.reduce(
-        AsyncReducer.lastWhere(async (v) => v >= 10, {
-          negate: true,
-          otherwise: fallback,
-        })
-      )
-    ).toBe(3);
-  });
-
   it('last', async () => {
     expect(await AsyncStream.empty<number>().reduce(AsyncReducer.last())).toBe(
       undefined
@@ -293,162 +151,6 @@ describe('AsyncReducer', () => {
     expect(
       await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.last(fallback))
     ).toBe(3);
-  });
-
-  it('some', async () => {
-    expect(
-      await AsyncStream.empty<number>().reduce(
-        AsyncReducer.some(async (v) => v > 2)
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.some(async (v) => v > 2)
-      )
-    ).toBe(true);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.some(async (v) => v > 10)
-      )
-    ).toBe(false);
-
-    expect(
-      await AsyncStream.empty<number>().reduce(
-        AsyncReducer.some(async (v) => v <= 2, { negate: true })
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.some(async (v) => v <= 2, { negate: true })
-      )
-    ).toBe(true);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.some(async (v) => v <= 10, { negate: true })
-      )
-    ).toBe(false);
-  });
-
-  it('every', async () => {
-    expect(
-      await AsyncStream.empty<number>().reduce(
-        AsyncReducer.every(async (v) => v > 2)
-      )
-    ).toBe(true);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.every(async (v) => v > 2)
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.every(async (v) => v > 10)
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.every(async (v) => v > 0)
-      )
-    ).toBe(true);
-
-    expect(
-      await AsyncStream.empty<number>().reduce(
-        AsyncReducer.every(async (v) => v <= 2, { negate: true })
-      )
-    ).toBe(true);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.every(async (v) => v <= 2, { negate: true })
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.every(async (v) => v <= 10, { negate: true })
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.every(async (v) => v <= 0, { negate: true })
-      )
-    ).toBe(true);
-  });
-
-  it('contains', async () => {
-    expect(
-      await AsyncStream.empty<number>().reduce(AsyncReducer.contains(5))
-    ).toBe(false);
-    expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.contains(5))).toBe(
-      false
-    );
-    expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.contains(2))).toBe(
-      true
-    );
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.contains(2, { eq: (v1, v2) => v1 + v2 === v1 })
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of([1, 2], [2, 3], [3, 4]).reduce(
-        AsyncReducer.contains([2, 1])
-      )
-    ).toBe(false);
-    expect(
-      await AsyncStream.of<readonly [number, number]>(
-        [1, 2],
-        [2, 3],
-        [3, 4]
-      ).reduce(AsyncReducer.contains([2, 1], { eq: Eq.tupleSymmetric() }))
-    ).toBe(true);
-    expect(
-      await AsyncStream.of<readonly [Number, number]>(
-        [1, 2],
-        [2, 3],
-        [3, 4]
-      ).reduce(AsyncReducer.contains([3, 1], { eq: Eq.tupleSymmetric() }))
-    ).toBe(false);
-
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(
-        AsyncReducer.contains(5, { negate: true })
-      )
-    ).toBe(true);
-
-    expect(
-      await AsyncStream.of(5, 5, 3, 5).reduce(
-        AsyncReducer.contains(5, { negate: true })
-      )
-    ).toBe(true);
-
-    expect(
-      await AsyncStream.of(5, 5, 5, 5).reduce(
-        AsyncReducer.contains(5, { negate: true })
-      )
-    ).toBe(false);
-  });
-
-  it('and', async () => {
-    expect(await AsyncStream.empty<boolean>().reduce(AsyncReducer.and)).toBe(
-      true
-    );
-    expect(await AsyncStream.of(true, true).reduce(AsyncReducer.and)).toBe(
-      true
-    );
-    expect(await AsyncStream.of(true, false).reduce(AsyncReducer.and)).toBe(
-      false
-    );
-  });
-
-  it('or', async () => {
-    expect(await AsyncStream.empty<boolean>().reduce(AsyncReducer.or)).toBe(
-      false
-    );
-    expect(await AsyncStream.of(false, false).reduce(AsyncReducer.or)).toBe(
-      false
-    );
-    expect(await AsyncStream.of(true, false).reduce(AsyncReducer.or)).toBe(
-      true
-    );
   });
 
   it('isEmpty', async () => {
@@ -467,61 +169,6 @@ describe('AsyncReducer', () => {
     expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.nonEmpty)).toBe(
       true
     );
-  });
-
-  it('toArray', async () => {
-    expect(
-      await AsyncStream.empty<number>().reduce(AsyncReducer.toArray())
-    ).toEqual([]);
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.toArray())
-    ).toEqual([1, 2, 3]);
-  });
-
-  it('toJSMap', async () => {
-    const map1 = await AsyncStream.empty<[number, string]>().reduce(
-      AsyncReducer.toJSMap()
-    );
-    expect(map1.size).toBe(0);
-
-    const map2 = await AsyncStream.of(
-      [1, 'a'],
-      [2, 'b'],
-      [3, 'b'],
-      [3, 'c']
-    ).reduce(AsyncReducer.toJSMap());
-    expect(map2.size).toBe(3);
-  });
-
-  it('toJSSet', async () => {
-    const set1 = await AsyncStream.empty<number>().reduce(
-      AsyncReducer.toJSSet()
-    );
-    expect(set1.size).toBe(0);
-
-    const set2 = await AsyncStream.of(1, 2, 3, 3).reduce(
-      AsyncReducer.toJSSet()
-    );
-    expect(set2.size).toBe(3);
-  });
-
-  it('toJSObject', async () => {
-    const obj1 = await AsyncStream.empty<[string, number]>().reduce(
-      AsyncReducer.toJSObject()
-    );
-    expect(obj1).toEqual({});
-
-    const obj2 = await AsyncStream.of(
-      ['a', 1],
-      ['b', 2],
-      ['b', 3],
-      ['c', 3]
-    ).reduce(AsyncReducer.toJSObject());
-    expect(obj2).toEqual({
-      a: 1,
-      b: 3,
-      c: 3,
-    });
   });
 
   it('filterInput', async () => {
@@ -642,16 +289,18 @@ describe('AsyncReducer', () => {
   });
 
   it('pipe', async () => {
-    const red = AsyncReducer.sum.pipe(AsyncReducer.join({ sep: ', ' }));
+    const red = AsyncReducer.from(Reducer.sum).pipe(
+      Reducer.join<number>({ sep: ', ' })
+    );
     expect(await AsyncStream.empty<number>().reduce(red)).toEqual('');
     expect(await AsyncStream.of(1).reduce(red)).toEqual('1');
     // expect(await AsyncStream.of(1, 2, 3).reduce(red)).toEqual('1, 3, 6');
   });
 
   it('pipe 2', async () => {
-    const red = AsyncReducer.sum.pipe(
-      AsyncReducer.product,
-      AsyncReducer.join({ sep: ', ' })
+    const red = AsyncReducer.from(Reducer.sum).pipe(
+      AsyncReducer.from(Reducer.product),
+      AsyncReducer.from(Reducer.join({ sep: ', ' }))
     );
     expect(await AsyncStream.empty<number>().reduce(red)).toEqual('');
     expect(await AsyncStream.of(1).reduce(red)).toEqual('1');
@@ -661,17 +310,19 @@ describe('AsyncReducer', () => {
 
   it('chain', async () => {
     {
-      const red = AsyncReducer.toArray<number>()
+      const red = AsyncReducer.from(Reducer.toArray<number>())
         .takeInput(2)
-        .chain(AsyncReducer.toArray<number>().takeInput(2));
+        .chain(Reducer.toArray<number>().takeInput(2));
 
       expect(await AsyncStream.of(1, 2, 3, 4, 5).reduce(red)).toEqual([3, 4]);
     }
 
     {
-      const red = AsyncReducer.sum
+      const red = AsyncReducer.from(Reducer.sum)
         .takeInput(2)
-        .chain((v) => AsyncReducer.product.mapOutput((o) => o + v));
+        .chain((v) =>
+          AsyncReducer.from(Reducer.product).mapOutput((o) => o + v)
+        );
 
       expect(await AsyncStream.of(1, 2, 3, 4).reduce(red)).toEqual(15);
     }
@@ -679,42 +330,11 @@ describe('AsyncReducer', () => {
 });
 
 describe('AsyncReducers', () => {
-  it('AsyncReducer.and', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.and)).toBe(true);
-    expect(await AsyncStream.of(true).reduce(AsyncReducer.and)).toBe(true);
-    expect(await AsyncStream.of(true, true).reduce(AsyncReducer.and)).toBe(
-      true
-    );
-    expect(await AsyncStream.of(false).reduce(AsyncReducer.and)).toBe(false);
-    expect(await AsyncStream.of(false, false).reduce(AsyncReducer.and)).toBe(
-      false
-    );
-    expect(await AsyncStream.of(false, true).reduce(AsyncReducer.and)).toBe(
-      false
-    );
-    expect(await AsyncStream.of(true, false).reduce(AsyncReducer.and)).toBe(
-      false
-    );
-
-    expect(
-      await AsyncStream.of(true, true, false, true)
-        .reduceStream(AsyncReducer.and)
-        .toArray()
-    ).toEqual([true, true, false]);
-  });
-
-  it('AsyncReducer.average', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.average)).toBe(0);
-    expect(
-      await AsyncStream.of(0, 0, 0).reduceStream(AsyncReducer.average).toArray()
-    ).toEqual([0, 0, 0]);
-    expect(
-      await AsyncStream.of(0, 2, 4).reduceStream(AsyncReducer.average).toArray()
-    ).toEqual([0, 1, 2]);
-  });
-
   it('AsyncReducer.combineArr', async () => {
-    const r = AsyncReducer.combine([AsyncReducer.sum, AsyncReducer.average]);
+    const r = AsyncReducer.combine([
+      AsyncReducer.from(Reducer.sum),
+      Reducer.average,
+    ]);
 
     expect(await AsyncStream.empty().reduce(r)).toEqual([0, 0]);
     expect(await AsyncStream.of(0, 0, 0).reduceStream(r).toArray()).toEqual([
@@ -730,7 +350,10 @@ describe('AsyncReducers', () => {
   });
 
   it('AsyncReducer.combineArr with halt', async () => {
-    const r = AsyncReducer.combine([AsyncReducer.sum, AsyncReducer.product]);
+    const r = AsyncReducer.combine([
+      AsyncReducer.from(Reducer.sum),
+      AsyncReducer.from(Reducer.product),
+    ]);
 
     expect(await AsyncStream.empty().reduce(r)).toEqual([0, 1]);
     expect(await AsyncStream.of(0, 0, 0).reduceStream(r).toArray()).toEqual([
@@ -747,8 +370,8 @@ describe('AsyncReducers', () => {
 
   it('AsyncReducer.combineArr with stateToResult', async () => {
     const r = AsyncReducer.combine([
-      AsyncReducer.sum.mapOutput(async (v) => v + 1),
-      AsyncReducer.product,
+      AsyncReducer.from(Reducer.sum).mapOutput(async (v) => v + 1),
+      AsyncReducer.from(Reducer.product),
     ]);
 
     expect(await AsyncStream.empty().reduce(r)).toEqual([1, 1]);
@@ -766,8 +389,8 @@ describe('AsyncReducers', () => {
 
   it('AsyncReducer.combineObj', async () => {
     const r = AsyncReducer.combine({
-      sum: AsyncReducer.sum,
-      avg: AsyncReducer.average,
+      sum: AsyncReducer.from(Reducer.sum),
+      avg: AsyncReducer.from(Reducer.average),
     });
 
     expect(await AsyncStream.empty().reduce(r)).toEqual({ sum: 0, avg: 0 });
@@ -785,8 +408,8 @@ describe('AsyncReducers', () => {
 
   it('AsyncReducer.combineObj with halt', async () => {
     const r = AsyncReducer.combine({
-      sum: AsyncReducer.sum,
-      prod: AsyncReducer.product,
+      sum: AsyncReducer.from(Reducer.sum),
+      prod: AsyncReducer.from(Reducer.product),
     });
 
     expect(await AsyncStream.empty().reduce(r)).toEqual({ sum: 0, prod: 1 });
@@ -804,8 +427,8 @@ describe('AsyncReducers', () => {
 
   it('AsyncReducer.combineObj with stateToResult', async () => {
     const r = AsyncReducer.combine({
-      sum: AsyncReducer.sum.mapOutput(async (v) => v + 1),
-      prod: AsyncReducer.product,
+      sum: AsyncReducer.from(Reducer.sum).mapOutput(async (v) => v + 1),
+      prod: AsyncReducer.from(Reducer.product),
     });
 
     expect(await AsyncStream.empty().reduce(r)).toEqual({ sum: 1, prod: 1 });
@@ -821,35 +444,6 @@ describe('AsyncReducers', () => {
     ]);
   });
 
-  it('AsyncReducer.contains', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.contains(6))).toBe(
-      false
-    );
-    expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.contains(6))).toBe(
-      false
-    );
-    expect(await AsyncStream.of(1, 6, 3).reduce(AsyncReducer.contains(6))).toBe(
-      true
-    );
-    expect(
-      await AsyncStream.of(1, 6, 2, 3, 8)
-        .reduceStream(AsyncReducer.contains(6))
-        .toArray()
-    ).toEqual([false, true]);
-  });
-
-  it('AsyncReducer.every', async () => {
-    const r = AsyncReducer.every(async (v: number) => v > 5);
-    expect(await AsyncStream.empty().reduce(r)).toBe(true);
-    expect(await AsyncStream.of(1, 2, 3).reduce(r)).toBe(false);
-    expect(await AsyncStream.of(7, 8, 9).reduce(r)).toBe(true);
-    expect(await AsyncStream.of(9, 7, 5, 8).reduceStream(r).toArray()).toEqual([
-      true,
-      true,
-      false,
-    ]);
-  });
-
   it('AsyncReducer.first', async () => {
     expect(
       await AsyncStream.empty().reduce(AsyncReducer.first())
@@ -860,24 +454,6 @@ describe('AsyncReducers', () => {
     expect(
       await AsyncStream.of(1, 2, 3).reduceStream(AsyncReducer.first()).toArray()
     ).toEqual([1]);
-  });
-
-  it('AsyncReducer.firstWhere', async () => {
-    const r1 = AsyncReducer.firstWhere(async (v: number) => v >= 5);
-    const r2 = AsyncReducer.firstWhere(async (v: number) => v >= 5, {
-      otherwise: -5,
-    });
-
-    expect(await AsyncStream.empty().reduce(r1)).toBeUndefined();
-    expect(await AsyncStream.empty().reduce(r2)).toBe(-5);
-    expect(await AsyncStream.of(1, 10, 2, 11, 3).reduce(r1)).toBe(10);
-    expect(await AsyncStream.of(1, 10, 2, 11, 3).reduce(r2)).toBe(10);
-    expect(
-      await AsyncStream.of(1, 10, 2, 11, 3).reduceStream(r1).toArray()
-    ).toEqual([undefined, 10]);
-    expect(
-      await AsyncStream.of(1, 10, 2, 11, 3).reduceStream(r2).toArray()
-    ).toEqual([-5, 10]);
   });
 
   it('AsyncReducer.isEmpty', async () => {
@@ -901,24 +477,6 @@ describe('AsyncReducers', () => {
     expect(
       await AsyncStream.of(1, 2, 3).reduceStream(AsyncReducer.last()).toArray()
     ).toEqual([1, 2, 3]);
-  });
-
-  it('AsyncReducer.lastWhere', async () => {
-    const r1 = AsyncReducer.lastWhere(async (v: number) => v >= 5);
-    const r2 = AsyncReducer.lastWhere(async (v: number) => v >= 5, {
-      otherwise: -5,
-    });
-
-    expect(await AsyncStream.empty().reduce(r1)).toBeUndefined();
-    expect(await AsyncStream.empty().reduce(r2)).toBe(-5);
-    expect(await AsyncStream.of(1, 10, 2, 11, 3).reduce(r1)).toBe(11);
-    expect(await AsyncStream.of(1, 10, 2, 11, 3).reduce(r2)).toBe(11);
-    expect(
-      await AsyncStream.of(1, 10, 2, 11, 3).reduceStream(r1).toArray()
-    ).toEqual([undefined, 10, 10, 11, 11]);
-    expect(
-      await AsyncStream.of(1, 10, 2, 11, 3).reduceStream(r2).toArray()
-    ).toEqual([-5, 10, 10, 11, 11]);
   });
 
   it('AsyncReducer.max', async () => {
@@ -1018,119 +576,5 @@ describe('AsyncReducers', () => {
         .reduceStream(AsyncReducer.nonEmpty)
         .toArray()
     ).toEqual([true]);
-  });
-
-  it('AsyncReducer.or', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.or)).toBe(false);
-    expect(await AsyncStream.of(true).reduce(AsyncReducer.or)).toBe(true);
-    expect(await AsyncStream.of(true, true).reduce(AsyncReducer.or)).toBe(true);
-    expect(await AsyncStream.of(false).reduce(AsyncReducer.or)).toBe(false);
-    expect(await AsyncStream.of(false, false).reduce(AsyncReducer.or)).toBe(
-      false
-    );
-    expect(await AsyncStream.of(false, true).reduce(AsyncReducer.or)).toBe(
-      true
-    );
-    expect(await AsyncStream.of(true, false).reduce(AsyncReducer.or)).toBe(
-      true
-    );
-
-    expect(
-      await AsyncStream.of(false, false, true, false)
-        .reduceStream(AsyncReducer.or)
-        .toArray()
-    ).toEqual([false, false, true]);
-  });
-
-  it('AsyncReducer.product', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.product)).toBe(1);
-    expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.product)).toBe(6);
-    expect(await AsyncStream.of(1, 0, 3).reduce(AsyncReducer.product)).toBe(0);
-
-    expect(
-      await AsyncStream.of(1, 2, 3, 0, 4)
-        .reduceStream(AsyncReducer.product)
-        .toArray()
-    ).toEqual([1, 2, 6, 0]);
-  });
-
-  it('AsyncReducer.some', async () => {
-    const r = AsyncReducer.some(async (v: number) => v > 5);
-    expect(await AsyncStream.empty().reduce(r)).toBe(false);
-    expect(await AsyncStream.of(1, 2, 3).reduce(r)).toBe(false);
-    expect(await AsyncStream.of(1, 8, 3).reduce(r)).toBe(true);
-    expect(await AsyncStream.of(1, 2, 7, 3).reduceStream(r).toArray()).toEqual([
-      false,
-      false,
-      true,
-    ]);
-  });
-
-  it('AsyncReducer.sum', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.sum)).toBe(0);
-    expect(await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.sum)).toBe(6);
-    expect(await AsyncStream.of(1, 0, 3).reduce(AsyncReducer.sum)).toBe(4);
-
-    expect(
-      await AsyncStream.of(1, 2, 3, 0, 4)
-        .reduceStream(AsyncReducer.sum)
-        .toArray()
-    ).toEqual([1, 3, 6, 6, 10]);
-  });
-
-  it('AsyncReducer.toArray', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.toArray())).toEqual(
-      []
-    );
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.toArray())
-    ).toEqual([1, 2, 3]);
-
-    expect(
-      await AsyncStream.of(1, 2, 3)
-        .reduceStream(AsyncReducer.toArray())
-        .toArray()
-    ).toEqual([[1], [1, 2], [1, 2, 3]]);
-  });
-
-  it('AsyncReducer.toJSMap', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.toJSMap())).toEqual(
-      new Map()
-    );
-    expect(
-      await AsyncStream.of([1, 'a'], [2, 'b']).reduce(AsyncReducer.toJSMap())
-    ).toEqual(
-      new Map([
-        [1, 'a'],
-        [2, 'b'],
-      ])
-    );
-
-    expect(
-      await AsyncStream.of([1, 'a'], [2, 'b'])
-        .reduceStream(AsyncReducer.toJSMap())
-        .toArray()
-    ).toEqual([
-      new Map([[1, 'a']]),
-      new Map([
-        [1, 'a'],
-        [2, 'b'],
-      ]),
-    ]);
-  });
-
-  it('AsyncReducer.toJSSet', async () => {
-    expect(await AsyncStream.empty().reduce(AsyncReducer.toJSSet())).toEqual(
-      new Set()
-    );
-    expect(
-      await AsyncStream.of(1, 2, 3).reduce(AsyncReducer.toJSSet())
-    ).toEqual(new Set([1, 2, 3]));
-
-    expect(
-      await AsyncStream.of(1, 2, 3)
-        .reduceStream(AsyncReducer.toJSSet())
-        .toArray()
-    ).toEqual([new Set([1]), new Set([1, 2]), new Set([1, 2, 3])]);
   });
 });

--- a/packages/stream/test/async-transformer.test.mts
+++ b/packages/stream/test/async-transformer.test.mts
@@ -2,6 +2,8 @@ import {
   AsyncReducer,
   AsyncStream,
   AsyncTransformer,
+  Reducer,
+  Transformer,
 } from '../src/main/index.mjs';
 
 describe('AsyncTransformer', () => {
@@ -51,7 +53,7 @@ describe('AsyncTransformer', () => {
         .transform(
           AsyncTransformer.window(3, {
             skipAmount: 1,
-            collector: AsyncReducer.toJSSet(),
+            collector: AsyncReducer.from(Reducer.toJSSet()),
           })
         )
         .toArray()
@@ -66,12 +68,12 @@ describe('AsyncTransformer', () => {
   it('distinctPrevious', async () => {
     expect(
       await AsyncStream.empty<number>()
-        .transform(AsyncTransformer.distinctPrevious())
+        .transform(AsyncTransformer.from(Transformer.distinctPrevious()))
         .toArray()
     ).toEqual([]);
     expect(
       await AsyncStream.of(1, 2, 2, 3, 1, 1, 3)
-        .transform(AsyncTransformer.distinctPrevious())
+        .transform(AsyncTransformer.from(Transformer.distinctPrevious()))
         .toArray()
     ).toEqual([1, 2, 3, 1, 3]);
   });

--- a/packages/stream/test/async-transformer.test.mts
+++ b/packages/stream/test/async-transformer.test.mts
@@ -53,7 +53,7 @@ describe('AsyncTransformer', () => {
         .transform(
           AsyncTransformer.window(3, {
             skipAmount: 1,
-            collector: AsyncReducer.from(Reducer.toJSSet()),
+            collector: Reducer.toJSSet<number>(),
           })
         )
         .toArray()
@@ -68,13 +68,74 @@ describe('AsyncTransformer', () => {
   it('distinctPrevious', async () => {
     expect(
       await AsyncStream.empty<number>()
-        .transform(AsyncTransformer.from(Transformer.distinctPrevious()))
+        .transform(
+          AsyncTransformer.from(Transformer.distinctPrevious<number>())
+        )
         .toArray()
     ).toEqual([]);
     expect(
       await AsyncStream.of(1, 2, 2, 3, 1, 1, 3)
-        .transform(AsyncTransformer.from(Transformer.distinctPrevious()))
+        .transform(
+          AsyncTransformer.from(Transformer.distinctPrevious<number>())
+        )
         .toArray()
     ).toEqual([1, 2, 3, 1, 3]);
+  });
+
+  it('flatMap', async () => {
+    expect(
+      await AsyncStream.empty<number>()
+        .transform(AsyncTransformer.flatMap(async (v) => [v, v]))
+        .toArray()
+    ).toEqual([]);
+
+    expect(
+      await AsyncStream.of(1, 2, 3)
+        .transform(AsyncTransformer.flatMap(async (v) => [v, v]))
+        .toArray()
+    ).toEqual([1, 1, 2, 2, 3, 3]);
+  });
+
+  it('filter', async () => {
+    async function isEven(v: number) {
+      return v % 2 === 0;
+    }
+
+    expect(
+      await AsyncStream.empty<number>()
+        .transform(AsyncTransformer.filter(isEven))
+        .toArray()
+    ).toEqual([]);
+    expect(
+      await AsyncStream.of(1, 2, 3)
+        .transform(AsyncTransformer.filter(isEven))
+        .toArray()
+    ).toEqual([2]);
+    expect(
+      await AsyncStream.of(1, 2, 3)
+        .transform(AsyncTransformer.filter(isEven, { negate: true }))
+        .toArray()
+    ).toEqual([1, 3]);
+  });
+
+  it('collect', async () => {
+    expect(
+      await AsyncStream.empty<number>()
+        .transform(
+          AsyncTransformer.collect(async (v, _, skip) =>
+            v % 2 === 0 ? String(v) : skip
+          )
+        )
+        .toArray()
+    ).toEqual([]);
+    expect(
+      await AsyncStream.of(1, 2, 3, 4)
+        .transform(
+          AsyncTransformer.collect(async (v, _, skip) =>
+            v % 2 === 0 ? String(v) : skip
+          )
+        )
+        .toArray()
+    ).toEqual(['2', '4']);
   });
 });

--- a/packages/stream/test/reducer.test.mts
+++ b/packages/stream/test/reducer.test.mts
@@ -10,7 +10,7 @@ describe('Reducer', () => {
       (v) => v + 1
     );
     expect(r.next(6, 7, 8, () => {})).toBe(6 + 7 + 8);
-    expect(r.stateToResult(5)).toBe(6);
+    expect(r.stateToResult(5, 3, false)).toBe(6);
   });
 
   it('createMono', () => {
@@ -20,7 +20,7 @@ describe('Reducer', () => {
       (v) => v + 1
     );
     expect(r.next(6, 7, 8, () => {})).toBe(6 + 7 + 8);
-    expect(r.stateToResult(5)).toBe(6);
+    expect(r.stateToResult(5, 3, false)).toBe(6);
   });
 
   it('createOutput', () => {
@@ -29,7 +29,7 @@ describe('Reducer', () => {
       (v, n, i) => v + n + i
     );
     expect(r.next(6, 7, 8, () => {})).toBe(6 + 7 + 8);
-    expect(r.stateToResult(5)).toBe(5);
+    expect(r.stateToResult(5, 3, false)).toBe(5);
   });
 
   it('sum', () => {
@@ -105,51 +105,6 @@ describe('Reducer', () => {
   it('count', () => {
     expect(Stream.empty<number>().reduce(Reducer.count())).toBe(0);
     expect(Stream.of(1, 2, 3).reduce(Reducer.count())).toBe(3);
-    expect(Stream.of(1, 2, 3).reduce(Reducer.count((v) => v > 2))).toBe(1);
-    expect(
-      Stream.of(1, 2, 3).reduce(Reducer.count((v) => v > 2, { negate: true }))
-    ).toBe(2);
-  });
-
-  it('firstWhere', () => {
-    const s = Stream.of(1, 2, 3);
-    expect(s.reduce(Reducer.firstWhere((v) => v === 2))).toBe(2);
-    expect(
-      s.reduce(Reducer.firstWhere((v) => v === 2, { otherwise: 'a' }))
-    ).toBe(2);
-    expect(s.reduce(Reducer.firstWhere((v) => v > 10))).toBe(undefined);
-    expect(
-      s.reduce(Reducer.firstWhere((v) => v > 10, { otherwise: 'a' }))
-    ).toBe('a');
-    expect(s.reduce(Reducer.firstWhere((v) => v < 10))).toBe(1);
-    expect(
-      s.reduce(Reducer.firstWhere((v) => v < 10, { otherwise: 'a' }))
-    ).toBe(1);
-
-    expect(s.reduce(Reducer.firstWhere((v) => v === 2, { negate: true }))).toBe(
-      1
-    );
-    expect(
-      s.reduce(
-        Reducer.firstWhere((v) => v === 2, { negate: true, otherwise: 'a' })
-      )
-    ).toBe(1);
-    expect(s.reduce(Reducer.firstWhere((v) => v < 10, { negate: true }))).toBe(
-      undefined
-    );
-    expect(
-      s.reduce(
-        Reducer.firstWhere((v) => v < 10, { negate: true, otherwise: 'a' })
-      )
-    ).toBe('a');
-    expect(s.reduce(Reducer.firstWhere((v) => v > 10, { negate: true }))).toBe(
-      1
-    );
-    expect(
-      s.reduce(
-        Reducer.firstWhere((v) => v > 10, { negate: true, otherwise: 'a' })
-      )
-    ).toBe(1);
   });
 
   it('first', () => {
@@ -159,52 +114,20 @@ describe('Reducer', () => {
     expect(Stream.of(1, 2, 3).reduce(Reducer.first('a'))).toBe(1);
   });
 
-  it('lastWhere', () => {
-    const s = Stream.of(1, 2, 3);
-    expect(s.reduce(Reducer.lastWhere((v) => v === 2))).toBe(2);
-    expect(
-      s.reduce(Reducer.lastWhere((v) => v === 2, { otherwise: 'a' }))
-    ).toBe(2);
-    expect(s.reduce(Reducer.lastWhere((v) => v > 10))).toBe(undefined);
-    expect(s.reduce(Reducer.lastWhere((v) => v > 10, { otherwise: 'a' }))).toBe(
-      'a'
-    );
-    expect(s.reduce(Reducer.lastWhere((v) => v < 10))).toBe(3);
-    expect(s.reduce(Reducer.lastWhere((v) => v < 10, { otherwise: 'a' }))).toBe(
-      3
-    );
-
-    expect(s.reduce(Reducer.lastWhere((v) => v === 2, { negate: true }))).toBe(
-      3
-    );
-    expect(
-      s.reduce(
-        Reducer.lastWhere((v) => v === 2, { negate: true, otherwise: 'a' })
-      )
-    ).toBe(3);
-    expect(s.reduce(Reducer.lastWhere((v) => v < 10, { negate: true }))).toBe(
-      undefined
-    );
-    expect(
-      s.reduce(
-        Reducer.lastWhere((v) => v < 10, { negate: true, otherwise: 'a' })
-      )
-    ).toBe('a');
-    expect(s.reduce(Reducer.lastWhere((v) => v > 10, { negate: true }))).toBe(
-      3
-    );
-    expect(
-      s.reduce(
-        Reducer.lastWhere((v) => v > 10, { negate: true, otherwise: 'a' })
-      )
-    ).toBe(3);
-  });
-
   it('last', () => {
     expect(Stream.empty<number>().reduce(Reducer.last())).toBe(undefined);
     expect(Stream.empty<number>().reduce(Reducer.last('a'))).toBe('a');
     expect(Stream.of(1, 2, 3).reduce(Reducer.last())).toBe(3);
     expect(Stream.of(1, 2, 3).reduce(Reducer.last('a'))).toBe(3);
+  });
+
+  it('single', () => {
+    expect(Stream.empty<number>().reduce(Reducer.single())).toBe(undefined);
+    expect(Stream.empty<number>().reduce(Reducer.single('a'))).toBe('a');
+    expect(Stream.of(1, 2, 3).reduce(Reducer.single())).toBe(undefined);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.single('a'))).toBe('a');
+    expect(Stream.of(1).reduce(Reducer.single())).toBe(1);
+    expect(Stream.of(1).reduce(Reducer.single('a'))).toBe(1);
   });
 
   it('some', () => {
@@ -237,6 +160,17 @@ describe('Reducer', () => {
     expect(
       Stream.of(1, 2, 3).reduce(Reducer.every((v) => v <= 0, { negate: true }))
     ).toBe(true);
+  });
+
+  it('equals', () => {
+    expect(Stream.empty<number>().reduce(Reducer.equals([]))).toBe(true);
+    expect(Stream.empty<number>().reduce(Reducer.equals([1, 2, 3]))).toBe(
+      false
+    );
+    expect(Stream.of(1, 2, 3).reduce(Reducer.equals([]))).toBe(false);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.equals([1, 2, 3]))).toBe(true);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.equals([1, 2]))).toBe(false);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.equals([1, 2, 3, 4]))).toBe(false);
   });
 
   it('contains', () => {
@@ -273,6 +207,149 @@ describe('Reducer', () => {
     expect(
       Stream.of(5, 5, 5, 5).reduce(Reducer.contains(5, { negate: true }))
     ).toBe(false);
+
+    expect(Stream.of(1, 2, 3).reduce(Reducer.contains(2, { amount: 2 }))).toBe(
+      false
+    );
+
+    expect(
+      Stream.of(1, 2, 3, 2).reduce(Reducer.contains(2, { amount: 2 }))
+    ).toBe(true);
+
+    expect(
+      Stream.of(1, 2, 3).reduce(
+        Reducer.contains(2, { negate: true, amount: 2 })
+      )
+    ).toBe(true);
+  });
+
+  it('startsWithSlice', () => {
+    expect(Stream.empty<number>().reduce(Reducer.startsWithSlice([]))).toBe(
+      true
+    );
+    expect(Stream.of(1, 2, 3).reduce(Reducer.startsWithSlice([]))).toBe(true);
+
+    expect(
+      Stream.empty<number>().reduce(Reducer.startsWithSlice([1, 2, 3]))
+    ).toBe(false);
+    expect(Stream.of(1, 2).reduce(Reducer.startsWithSlice([1, 2, 3]))).toBe(
+      false
+    );
+    expect(Stream.of(1, 2, 3).reduce(Reducer.startsWithSlice([1, 2, 3]))).toBe(
+      true
+    );
+    expect(
+      Stream.of(1, 2, 3, 4).reduce(Reducer.startsWithSlice([1, 2, 3]))
+    ).toBe(true);
+    expect(
+      Stream.of(1, 1, 2, 3, 4).reduce(Reducer.startsWithSlice([1, 2, 3]))
+    ).toBe(false);
+    expect(
+      Stream.of(2, 1, 2, 3, 4).reduce(Reducer.startsWithSlice([1, 2, 3]))
+    ).toBe(false);
+    expect(
+      Stream.of(1, 2, 3).reduce(
+        Reducer.startsWithSlice([1, 2, 3], { amount: 2 })
+      )
+    ).toBe(false);
+    expect(
+      Stream.of(1, 2, 3, 1, 2, 3).reduce(
+        Reducer.startsWithSlice([1, 2, 3], { amount: 2 })
+      )
+    ).toBe(true);
+    expect(
+      Stream.of(1, 2, 3, 1, 2, 4).reduce(
+        Reducer.startsWithSlice([1, 2, 3], { amount: 2 })
+      )
+    ).toBe(false);
+    expect(
+      Stream.of(1, 2, 3, 1, 2, 3, 1, 2, 3).reduce(
+        Reducer.startsWithSlice([1, 2, 3], { amount: 2 })
+      )
+    ).toBe(true);
+  });
+
+  it('endsWithSlice', () => {
+    expect(Stream.empty<number>().reduce(Reducer.endsWithSlice([]))).toBe(true);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.endsWithSlice([]))).toBe(true);
+
+    expect(Stream.empty<number>().reduce(Reducer.endsWithSlice([1]))).toBe(
+      false
+    );
+    expect(Stream.of(1, 2, 3).reduce(Reducer.endsWithSlice([1]))).toBe(false);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.endsWithSlice([1, 2, 3]))).toBe(
+      true
+    );
+    expect(Stream.of(1, 2, 3, 4).reduce(Reducer.endsWithSlice([1, 2, 3]))).toBe(
+      false
+    );
+    expect(Stream.of(1, 2, 3).reduce(Reducer.endsWithSlice([1, 2, 3, 4]))).toBe(
+      false
+    );
+    expect(Stream.of(1, 2, 3).reduce(Reducer.endsWithSlice([1, 2]))).toBe(
+      false
+    );
+
+    expect(
+      Stream.of(1, 2, 3, 1, 2, 3).reduce(
+        Reducer.endsWithSlice([1, 2, 3], { amount: 2 })
+      )
+    ).toBe(true);
+    expect(
+      Stream.of(1, 2, 3, 1, 2, 3).reduce(
+        Reducer.endsWithSlice([1, 2, 3], { amount: 3 })
+      )
+    ).toBe(false);
+
+    expect(Stream.of(1, 1, 2, 3).reduce(Reducer.endsWithSlice([1, 2, 3]))).toBe(
+      true
+    );
+    expect(
+      Stream.of(1, 1, 1, 2, 3).reduce(Reducer.endsWithSlice([1, 2, 3]))
+    ).toBe(true);
+    expect(
+      Stream.of(1, 2, 1, 2, 3).reduce(Reducer.endsWithSlice([1, 2, 3]))
+    ).toBe(true);
+  });
+
+  it('containsSlice', () => {
+    expect(Stream.empty<number>().reduce(Reducer.containsSlice([]))).toBe(true);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.containsSlice([]))).toBe(true);
+
+    expect(Stream.empty<number>().reduce(Reducer.containsSlice([1, 2]))).toBe(
+      false
+    );
+    expect(Stream.of(1, 2).reduce(Reducer.containsSlice([1, 2]))).toBe(true);
+    expect(Stream.of(1, 2, 3, 4).reduce(Reducer.containsSlice([1, 2]))).toBe(
+      true
+    );
+    expect(Stream.of(1, 2, 3, 4).reduce(Reducer.containsSlice([2, 3]))).toBe(
+      true
+    );
+    expect(Stream.of(1, 2, 3, 4).reduce(Reducer.containsSlice([3, 4]))).toBe(
+      true
+    );
+    expect(Stream.of(1, 2, 3, 4).reduce(Reducer.containsSlice([1, 4]))).toBe(
+      false
+    );
+
+    expect(
+      Stream.of(1, 2, 3, 4).reduce(Reducer.containsSlice([2, 3], { amount: 2 }))
+    ).toBe(false);
+    expect(
+      Stream.of(1, 2, 3, 4, 2, 3, 4).reduce(
+        Reducer.containsSlice([2, 3], { amount: 2 })
+      )
+    ).toBe(true);
+    expect(
+      Stream.of(1, 2, 3, 4, 2, 3, 4).reduce(
+        Reducer.containsSlice([2, 3], { amount: 3 })
+      )
+    ).toBe(false);
+
+    expect(
+      Stream.of(1, 1, 1, 2, 3, 4).reduce(Reducer.containsSlice([1, 1, 2, 3]))
+    ).toBe(true);
   });
 
   it('and', () => {
@@ -295,6 +372,66 @@ describe('Reducer', () => {
   it('nonEmpty', () => {
     expect(Stream.empty<number>().reduce(Reducer.nonEmpty)).toBe(false);
     expect(Stream.of(1, 2, 3).reduce(Reducer.nonEmpty)).toBe(true);
+  });
+
+  it('constant', () => {
+    expect(Stream.empty<number>().reduce(Reducer.constant(1))).toBe(1);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.constant(1))).toBe(1);
+
+    const redInstance = Reducer.constant(1).compile();
+    expect(redInstance.halted).toBe(true);
+    expect(redInstance.getOutput()).toBe(1);
+  });
+
+  it('combineFirstDone', () => {
+    expect(
+      Stream.empty<number>().reduce(Reducer.combineFirstDone([Reducer.sum]))
+    ).toBe(undefined);
+    expect(
+      Stream.empty<number>().reduce(Reducer.combineFirstDone([Reducer.sum], 2))
+    ).toBe(2);
+
+    expect(
+      Stream.empty<number>().reduce(
+        Reducer.combineFirstDone([
+          Reducer.sum.dropInput(2),
+          Reducer.constant(2),
+        ])
+      )
+    ).toBe(2);
+
+    expect(
+      Stream.of(1, 2, 3).reduce(
+        Reducer.combineFirstDone([
+          Reducer.sum.dropInput(2),
+          Reducer.constant(2),
+        ])
+      )
+    ).toBe(2);
+
+    expect(
+      Stream.of(1, 2, 3).reduce(
+        Reducer.combineFirstDone([Reducer.constant(3), Reducer.constant(2)])
+      )
+    ).toBe(3);
+
+    expect(
+      Stream.of(1, 2, 4).reduce(
+        Reducer.combineFirstDone([
+          Reducer.sum.takeInput(3),
+          Reducer.product.takeInput(3),
+        ])
+      )
+    ).toBe(7);
+
+    expect(
+      Stream.of(1, 2, 4).reduce(
+        Reducer.combineFirstDone([
+          Reducer.product.takeInput(3),
+          Reducer.sum.takeInput(3),
+        ])
+      )
+    ).toBe(8);
   });
 
   it('toArray', () => {
@@ -614,23 +751,6 @@ describe('Reducers', () => {
     ]);
   });
 
-  it('Reducer.firstWhere', () => {
-    const r1 = Reducer.firstWhere((v: number) => v >= 5);
-    const r2 = Reducer.firstWhere((v: number) => v >= 5, { otherwise: -5 });
-
-    expect(Stream.empty().reduce(r1)).toBeUndefined();
-    expect(Stream.empty().reduce(r2)).toBe(-5);
-    expect(Stream.of(1, 10, 2, 11, 3).reduce(r1)).toBe(10);
-    expect(Stream.of(1, 10, 2, 11, 3).reduce(r2)).toBe(10);
-    expect(Stream.of(1, 10, 2, 11, 3).reduceStream(r1).toArray()).toEqual([
-      undefined,
-      10,
-    ]);
-    expect(Stream.of(1, 10, 2, 11, 3).reduceStream(r2).toArray()).toEqual([
-      -5, 10,
-    ]);
-  });
-
   it('Reducer.isEmpty', () => {
     expect(Stream.empty().reduce(Reducer.isEmpty)).toBe(true);
     expect(Stream.of(1, 2, 3).reduce(Reducer.isEmpty)).toBe(false);
@@ -647,26 +767,6 @@ describe('Reducers', () => {
     expect(Stream.of(1, 2, 3).reduce(Reducer.last(5))).toBe(3);
     expect(Stream.of(1, 2, 3).reduceStream(Reducer.last()).toArray()).toEqual([
       1, 2, 3,
-    ]);
-  });
-
-  it('Reducer.lastWhere', () => {
-    const r1 = Reducer.lastWhere((v: number) => v >= 5);
-    const r2 = Reducer.lastWhere((v: number) => v >= 5, { otherwise: -5 });
-
-    expect(Stream.empty().reduce(r1)).toBeUndefined();
-    expect(Stream.empty().reduce(r2)).toBe(-5);
-    expect(Stream.of(1, 10, 2, 11, 3).reduce(r1)).toBe(11);
-    expect(Stream.of(1, 10, 2, 11, 3).reduce(r2)).toBe(11);
-    expect(Stream.of(1, 10, 2, 11, 3).reduceStream(r1).toArray()).toEqual([
-      undefined,
-      10,
-      10,
-      11,
-      11,
-    ]);
-    expect(Stream.of(1, 10, 2, 11, 3).reduceStream(r2).toArray()).toEqual([
-      -5, 10, 10, 11, 11,
     ]);
   });
 

--- a/packages/stream/test/reducer.test.mts
+++ b/packages/stream/test/reducer.test.mts
@@ -103,8 +103,8 @@ describe('Reducer', () => {
   });
 
   it('count', () => {
-    expect(Stream.empty<number>().reduce(Reducer.count())).toBe(0);
-    expect(Stream.of(1, 2, 3).reduce(Reducer.count())).toBe(3);
+    expect(Stream.empty<number>().reduce(Reducer.count)).toBe(0);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.count)).toBe(3);
   });
 
   it('first', () => {
@@ -479,7 +479,7 @@ describe('Reducer', () => {
 
   it('filterInput', () => {
     expect(
-      Stream.of(1, 2, 3).reduce(Reducer.count().filterInput((v) => v > 2))
+      Stream.of(1, 2, 3).reduce(Reducer.count.filterInput((v) => v > 2))
     ).toBe(1);
   });
 

--- a/packages/stream/test/reducer.test.mts
+++ b/packages/stream/test/reducer.test.mts
@@ -383,53 +383,41 @@ describe('Reducer', () => {
     expect(redInstance.getOutput()).toBe(1);
   });
 
-  it('combineFirstDone', () => {
-    expect(
-      Stream.empty<number>().reduce(Reducer.combineFirstDone([Reducer.sum]))
-    ).toBe(undefined);
-    expect(
-      Stream.empty<number>().reduce(Reducer.combineFirstDone([Reducer.sum], 2))
-    ).toBe(2);
+  it('race', () => {
+    expect(Stream.empty<number>().reduce(Reducer.race([Reducer.sum]))).toBe(
+      undefined
+    );
+    expect(Stream.empty<number>().reduce(Reducer.race([Reducer.sum], 2))).toBe(
+      2
+    );
 
     expect(
       Stream.empty<number>().reduce(
-        Reducer.combineFirstDone([
-          Reducer.sum.dropInput(2),
-          Reducer.constant(2),
-        ])
+        Reducer.race([Reducer.sum.dropInput(2), Reducer.constant(2)])
       )
     ).toBe(2);
 
     expect(
       Stream.of(1, 2, 3).reduce(
-        Reducer.combineFirstDone([
-          Reducer.sum.dropInput(2),
-          Reducer.constant(2),
-        ])
+        Reducer.race([Reducer.sum.dropInput(2), Reducer.constant(2)])
       )
     ).toBe(2);
 
     expect(
       Stream.of(1, 2, 3).reduce(
-        Reducer.combineFirstDone([Reducer.constant(3), Reducer.constant(2)])
+        Reducer.race([Reducer.constant(3), Reducer.constant(2)])
       )
     ).toBe(3);
 
     expect(
       Stream.of(1, 2, 4).reduce(
-        Reducer.combineFirstDone([
-          Reducer.sum.takeInput(3),
-          Reducer.product.takeInput(3),
-        ])
+        Reducer.race([Reducer.sum.takeInput(3), Reducer.product.takeInput(3)])
       )
     ).toBe(7);
 
     expect(
       Stream.of(1, 2, 4).reduce(
-        Reducer.combineFirstDone([
-          Reducer.product.takeInput(3),
-          Reducer.sum.takeInput(3),
-        ])
+        Reducer.race([Reducer.product.takeInput(3), Reducer.sum.takeInput(3)])
       )
     ).toBe(8);
   });
@@ -507,6 +495,17 @@ describe('Reducer', () => {
     expect(
       Stream.of(1, 2, 3).reduce(Reducer.average.mapOutput((v) => v * 2))
     ).toBe(4);
+  });
+
+  it('takeOutput', () => {
+    expect(Stream.of(1, 2, 3).reduce(Reducer.sum.takeOutput(0))).toBe(0);
+    expect(Stream.of(1, 2, 3).reduce(Reducer.sum.takeOutput(2))).toBe(3);
+  });
+
+  it('takeOutputUntil', () => {
+    expect(
+      Stream.of(1, 2, 3).reduce(Reducer.sum.takeOutputUntil((v) => v >= 3))
+    ).toBe(3);
   });
 
   it('takeInput', () => {

--- a/packages/stream/test/stream.test.mts
+++ b/packages/stream/test/stream.test.mts
@@ -1363,20 +1363,31 @@ describe('Stream methods', () => {
     ]);
   });
 
-  it('splitOnSeq', () => {
-    expect(Stream.empty<number>().splitOnSeq([1, 2, 3]).toArray()).toEqual([]);
-    expect(Stream.of(1, 2).splitOnSeq([1, 2, 3]).toArray()).toEqual([[1, 2]]);
-    expect(Stream.of(1, 2, 3).splitOnSeq([1, 2, 3]).toArray()).toEqual([[]]);
-    expect(Stream.of(1, 1, 2, 3).splitOnSeq([1, 2, 3]).toArray()).toEqual([
+  it('splitOnSlice', () => {
+    expect(Stream.empty<number>().splitOnSlice([1, 2, 3]).toArray()).toEqual(
+      []
+    );
+    expect(Stream.of(1, 2).splitOnSlice([10]).toArray()).toEqual([[1, 2]]);
+    expect(Stream.of(1, 2).splitOnSlice([1, 2, 3]).toArray()).toEqual([[1, 2]]);
+    expect(Stream.of(1, 2, 3).splitOnSlice([1, 2, 3]).toArray()).toEqual([[]]);
+    expect(Stream.of(2, 1, 2, 3).splitOnSlice([1, 2, 3]).toArray()).toEqual([
+      [2],
+    ]);
+    expect(Stream.of(1, 1, 2, 3).splitOnSlice([1, 2, 3]).toArray()).toEqual([
       [1],
     ]);
-    expect(Stream.of(1, 1, 2, 3, 3).splitOnSeq([1, 2, 3]).toArray()).toEqual([
+    expect(Stream.of(1, 1, 2, 3, 3).splitOnSlice([1, 2, 3]).toArray()).toEqual([
       [1],
       [3],
     ]);
     expect(
-      Stream.of(1, 1, 2, 3, 1, 2, 1, 2, 3, 1).splitOnSeq([1, 2, 3]).toArray()
+      Stream.of(1, 1, 2, 3, 1, 2, 1, 2, 3, 1).splitOnSlice([1, 2, 3]).toArray()
     ).toEqual([[1], [1, 2], [1]]);
+    expect(
+      Stream.of(1, 1, 2, 3, 1, 2, 3, 1, 2, 1, 2, 3, 1)
+        .splitOnSlice([1, 2, 3])
+        .toArray()
+    ).toEqual([[1], [], [1, 2], [1]]);
   });
 
   it('fold', () => {

--- a/packages/stream/test/stream.test.mts
+++ b/packages/stream/test/stream.test.mts
@@ -19,6 +19,24 @@ const streamRange7 = Stream.range({ start: 1, amount: 99 }).prepend(0);
 const streamRange8 = Stream.range({ amount: 100 }).filter(() => true);
 const arr = Stream.range({ start: 99, end: 0 }, { delta: -1 }).toArray();
 const streamRange9 = Stream.fromArray(arr, { reversed: true });
+const streamRange10 = Stream.range({ amount: 100 }).mapPure((v) => v);
+const streamRange11 = Stream.range({ amount: 100 }).filterPure({
+  pred: (v) => true,
+});
+const streamRange12 = Stream.range({ amount: 100 })
+  .indexed()
+  .map(([v]) => v);
+const streamRange13 = Stream.range({ amount: 100 }).collect((v) => v);
+const streamRange14 = Stream.range({ amount: 200 }).take(100);
+const streamRange15 = Stream.range({ start: -100, amount: 200 }).drop(100);
+const streamRange16 = Stream.applyMap(
+  streamRange1.map((v) => [v]),
+  (v) => v
+);
+const streamRange17 = Stream.applyFilter(
+  streamRange1.map((v) => [v]),
+  { pred: () => true }
+).map(([v]) => v);
 
 const sources = [
   streamRange1,
@@ -30,7 +48,17 @@ const sources = [
   streamRange7,
   streamRange8,
   streamRange9,
+  streamRange10,
+  streamRange11,
+  streamRange12,
+  streamRange13,
+  streamRange14,
+  streamRange15,
+  streamRange16,
+  streamRange17,
 ];
+
+const artificialEmpty = Stream.range({ amount: 3 }).filter(() => false);
 
 describe('Stream constructors', () => {
   it('empty', () => {
@@ -173,6 +201,29 @@ describe('Stream constructors', () => {
       Stream.unfold(0, (c, i, stop) => (c > 2 ? stop : c + i)).toArray()
     ).toEqual([0, 1, 3]);
   });
+
+  it('applyForEach', () => {
+    const source = Stream.range({ amount: 4 }).indexed();
+    let sum = 0;
+    Stream.applyForEach(source, (v1, v2) => (sum += v1 + v2));
+    expect(sum).toBe(12);
+  });
+
+  it('applyMap', () => {
+    const source = Stream.range({ amount: 4 }).indexed();
+    expect(Stream.applyMap(source, (v1, v2) => v1 + v2).toArray()).toEqual([
+      0, 2, 4, 6,
+    ]);
+  });
+
+  it('applyFilter', () => {
+    const source = Stream.range({ amount: 4 }).indexed();
+    expect(
+      Stream.applyFilter(source, { pred: (v1, v2) => v1 === v2 })
+        .map(([v]) => v)
+        .toArray()
+    ).toEqual([0, 1, 2, 3]);
+  });
 });
 
 describe('Stream methods', () => {
@@ -213,6 +264,8 @@ describe('Stream methods', () => {
     const s = Stream.of(1, 2, 3);
     expect(s.assumeNonEmpty()).toBe(s);
 
+    expect(artificialEmpty.assumeNonEmpty()).toBe(artificialEmpty);
+
     sources.forEach((source) => {
       expect(source.assumeNonEmpty()).toBe(source);
     });
@@ -221,12 +274,18 @@ describe('Stream methods', () => {
   it('asNormal', () => {
     const s = Stream.of(1, 2, 3);
     expect(s.asNormal()).toBe(s);
+
+    sources.forEach((source) =>
+      expect(source.assumeNonEmpty().asNormal()).toBe(source)
+    );
   });
 
   it('prepend', () => {
     expect(Stream.empty<number>().prepend(5).toArray()).toEqual([5]);
 
     expect(Stream.of(1, 2, 3).prepend(5).toArray()).toEqual([5, 1, 2, 3]);
+
+    expect(artificialEmpty.prepend(5).toArray()).toEqual([5]);
 
     sources.forEach((source) => {
       const arr = [5, ...source.toArray()];
@@ -238,6 +297,8 @@ describe('Stream methods', () => {
     expect(Stream.empty<number>().append(5).toArray()).toEqual([5]);
 
     expect(Stream.of(1, 2, 3).append(5).toArray()).toEqual([1, 2, 3, 5]);
+
+    expect(artificialEmpty.append(5).toArray()).toEqual([5]);
 
     sources.forEach((source) => {
       const arr = [...source.toArray(), 5];
@@ -320,6 +381,12 @@ describe('Stream methods', () => {
       [6, 2],
       [7, 3],
     ]);
+
+    sources.forEach((source) => {
+      expect(source.indexed().toArray()).toEqual(
+        source.toArray().map((v, i) => [i, v])
+      );
+    });
   });
 
   it('map', () => {
@@ -379,6 +446,60 @@ describe('Stream methods', () => {
 
     sources.forEach((source) => {
       expect(source.flatMap((v) => [v]).toArray()).toEqual(source.toArray());
+    });
+  });
+
+  it('flatZip', () => {
+    expect(Stream.empty().flatZip((v) => Stream.of(1))).toBe(Stream.empty());
+    expect(
+      Stream.of(1)
+        .flatZip((v) => Stream.empty())
+        .toArray()
+    ).toEqual([]);
+    expect(
+      Stream.of(1)
+        .flatZip((v) => Stream.of(2, 3))
+        .toArray()
+    ).toEqual([
+      [1, 2],
+      [1, 3],
+    ]);
+    expect(
+      Stream.of(1, 2, 3)
+        .flatZip((v) => Stream.of(v + 1))
+        .toArray()
+    ).toEqual([
+      [1, 2],
+      [2, 3],
+      [3, 4],
+    ]);
+    expect(
+      Stream.of(1, 2, 3)
+        .flatZip((v, i) => [i + 1])
+        .toArray()
+    ).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
+
+    expect(
+      Stream.of(1, 2, 3)
+        .flatZip((v, i) => [v, v])
+        .toArray()
+    ).toEqual([
+      [1, 1],
+      [1, 1],
+      [2, 2],
+      [2, 2],
+      [3, 3],
+      [3, 3],
+    ]);
+
+    sources.forEach((source) => {
+      expect(source.flatZip((v) => [v]).toArray()).toEqual(
+        source.map((v) => [v, v]).toArray()
+      );
     });
   });
 
@@ -588,6 +709,9 @@ describe('Stream methods', () => {
 
     expect(Stream.range({ start: 0 }).first()).toBe(0);
 
+    expect(artificialEmpty.first()).toBe(undefined);
+    expect(artificialEmpty.first(5)).toBe(5);
+
     sources.forEach((source) => {
       const first = source.toArray()[0];
       expect(source.first()).toBe(first);
@@ -599,6 +723,9 @@ describe('Stream methods', () => {
     expect(Stream.empty<number>().last()).toBeUndefined();
     expect(Stream.empty<number>().last(1)).toBe(1);
     expect(Stream.of(1, 2, 3).last()).toBe(3);
+
+    expect(artificialEmpty.last()).toBe(undefined);
+    expect(artificialEmpty.last(5)).toBe(5);
 
     sources.forEach((source) => {
       const last = Arr.last(source.toArray());
@@ -631,6 +758,23 @@ describe('Stream methods', () => {
       expect(source.filter((v) => v % 2 === 0).count()).toEqual(
         source.toArray().length / 2
       );
+    });
+  });
+
+  it('countElement', () => {
+    expect(Stream.empty<number>().countElement(5)).toBe(0);
+    expect(Stream.empty<number>().countElement(5, { negate: true })).toBe(0);
+
+    expect(Stream.of(1, 2, 3).countElement(2)).toBe(1);
+    expect(Stream.of(1, 2, 3).countElement(2, { negate: true })).toBe(2);
+    expect(Stream.of(1, 2, 3).countElement(5)).toBe(0);
+    expect(Stream.of(1, 2, 3).countElement(5, { negate: true })).toBe(3);
+
+    sources.forEach((source) => {
+      expect(source.countElement(50)).toBe(1);
+      expect(source.countElement(50, { negate: true })).toBe(99);
+      expect(source.countElement(200)).toBe(0);
+      expect(source.countElement(200, { negate: true })).toBe(100);
     });
   });
 
@@ -693,6 +837,7 @@ describe('Stream methods', () => {
     expect(Stream.empty().elementAt(0, 'a')).toBe('a');
     expect(Stream.of(1).elementAt(0, 'a')).toBe(1);
     expect(Stream.of(1).elementAt(1, 'a')).toBe('a');
+
     sources.forEach((source) => {
       expect(source.elementAt(0, 'a')).toBe(0);
       expect(source.elementAt(50, 'a')).toBe(50);
@@ -720,6 +865,7 @@ describe('Stream methods', () => {
         .indicesWhere((v) => v < 2)
         .toArray()
     ).toEqual([0, 2]);
+
     sources.forEach((source) => {
       expect(source.indicesWhere((v) => v >= 97).toArray()).toEqual([
         97, 98, 99,
@@ -747,6 +893,7 @@ describe('Stream methods', () => {
         .indicesWhere((v) => v >= 2, { negate: true })
         .toArray()
     ).toEqual([0, 2]);
+
     sources.forEach((source) => {
       expect(
         source.indicesWhere((v) => v < 97, { negate: true }).toArray()
@@ -762,6 +909,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1).indicesOf(1).toArray()).toEqual([0]);
     expect(Stream.of(1).indicesOf(2).toArray()).toEqual([]);
     expect(Stream.of(1, 2, 1).indicesOf(1).toArray()).toEqual([0, 2]);
+
     sources.forEach((source) => {
       expect(source.indicesOf(50).toArray()).toEqual([50]);
       expect(source.indicesOf(-1).toArray()).toEqual([]);
@@ -777,6 +925,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1, 2, 1).indicesOf(2, { negate: true }).toArray()).toEqual(
       [0, 2]
     );
+
     sources.forEach((source) => {
       expect(source.indicesOf(50, { negate: true }).toArray().length).toBe(99);
       expect(source.indicesOf(-1, { negate: true }).toArray().length).toBe(100);
@@ -798,6 +947,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1, 2, 1).indexWhere((v) => v < 2, { occurrance: 3 })).toBe(
       undefined
     );
+
     sources.forEach((source) => {
       expect(source.indexWhere((v) => v >= 50)).toEqual(50);
       expect(source.indexWhere((v) => v >= 50, { occurrance: 10 })).toEqual(59);
@@ -834,6 +984,7 @@ describe('Stream methods', () => {
         occurrance: 3,
       })
     ).toBe(undefined);
+
     sources.forEach((source) => {
       expect(source.indexWhere((v) => v < 50, { negate: true })).toEqual(50);
       expect(
@@ -854,6 +1005,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1, 2, 1).indexOf(3)).toBe(undefined);
     expect(Stream.of(1, 2, 1).indexOf(1, { occurrance: 2 })).toBe(2);
     expect(Stream.of(1, 2, 1).indexOf(1, { occurrance: 3 })).toBe(undefined);
+
     sources.forEach((source) => {
       expect(source.indexOf(50)).toEqual(50);
       expect(source.indexOf(50, { occurrance: 2 })).toEqual(undefined);
@@ -879,6 +1031,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1, 2, 1).indexOf(2, { negate: true, occurrance: 3 })).toBe(
       undefined
     );
+
     sources.forEach((source) => {
       expect(source.indexOf(10, { negate: true })).toEqual(0);
       expect(source.indexOf(50, { negate: true, occurrance: 2 })).toEqual(1);
@@ -892,6 +1045,7 @@ describe('Stream methods', () => {
     expect(Stream.empty().some((v) => false)).toBe(false);
     expect(Stream.of(1, 2, 3).some((v) => v === 2)).toBe(true);
     expect(Stream.of(1, 2, 3).some((v) => v === 10)).toBe(false);
+
     sources.forEach((source) => {
       expect(source.some((v) => v === 50)).toBe(true);
       expect(source.some((v) => v === -50)).toBe(false);
@@ -925,6 +1079,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1, 2, 3).every((v) => v < 3)).toBe(false);
     expect(Stream.of(1, 2, 3).every((v, i) => i >= 0)).toBe(true);
     expect(Stream.of(1, 2, 3).every((v, i) => i < 2)).toBe(false);
+
     sources.forEach((source) => {
       expect(source.every((v) => v < 50)).toBe(false);
       expect(source.every((v) => v >= 0)).toBe(true);
@@ -966,6 +1121,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1, 2, 1, 2, 1, 2).contains(2, { amount: 2 })).toBe(true);
     expect(Stream.of(1, 2, 1, 2, 1, 2).contains(2, { amount: 3 })).toBe(true);
     expect(Stream.of(1, 2, 1, 2, 1, 2).contains(2, { amount: 4 })).toBe(false);
+
     sources.forEach((source) => {
       expect(source.contains(50)).toBe(true);
       expect(source.contains(50, { amount: 2 })).toBe(false);
@@ -1007,6 +1163,20 @@ describe('Stream methods', () => {
     expect(Stream.of(1, 2, 3, 9, 8).containsSlice([1, 2, 3])).toBe(true);
     expect(Stream.of(9, 8, 1, 2, 3, 9, 8).containsSlice([1, 2, 3])).toBe(true);
     expect(Stream.of(9, 8, 1, 2, 3, 9, 8).containsSlice([1, 2, 4])).toBe(false);
+
+    expect(Stream.of(1, 2, 3, 1, 2, 3).containsSlice([2, 3])).toBe(true);
+    expect(
+      Stream.of(1, 2, 3, 1, 2, 3).containsSlice([2, 3], { amount: 2 })
+    ).toBe(true);
+    expect(
+      Stream.of(1, 2, 3, 1, 2, 3).containsSlice([2, 3], { amount: 3 })
+    ).toBe(false);
+
+    sources.forEach((source) => {
+      expect(source.containsSlice([50, 40])).toBe(false);
+      expect(source.containsSlice([50, 51])).toBe(true);
+      expect(source.containsSlice([50, 51], { amount: 2 })).toBe(false);
+    });
   });
 
   it('takeWhile', () => {
@@ -1070,6 +1240,7 @@ describe('Stream methods', () => {
         .dropWhile((v) => false)
         .toArray()
     ).toEqual([1]);
+
     sources.forEach((source) => {
       expect(source.dropWhile((v) => true).toArray()).toEqual([]);
       expect(source.dropWhile((v) => v < 97).toArray()).toEqual([97, 98, 99]);
@@ -1096,6 +1267,7 @@ describe('Stream methods', () => {
         .dropWhile((v) => true, { negate: true })
         .toArray()
     ).toEqual([1]);
+
     sources.forEach((source) => {
       expect(
         source.dropWhile((v) => false, { negate: true }).toArray()
@@ -1116,6 +1288,7 @@ describe('Stream methods', () => {
     const e = Stream.of(1, 2, 3);
     expect(e.take(10)).toBe(e);
     expect(Stream.of(1, 2, 3).take(2).toArray()).toEqual([1, 2]);
+
     sources.forEach((source) => {
       expect(source.take(3).toArray()).toEqual([0, 1, 2]);
     });
@@ -1127,6 +1300,7 @@ describe('Stream methods', () => {
     expect(Stream.of(1).drop(10)).toBe(Stream.empty());
     expect(Stream.of(1, 2, 3).drop(10)).toBe(Stream.empty());
     expect(Stream.of(1, 2, 3).drop(1).toArray()).toEqual([2, 3]);
+
     sources.forEach((source) => {
       expect(source.drop(97).toArray()).toEqual([97, 98, 99]);
     });
@@ -1141,6 +1315,7 @@ describe('Stream methods', () => {
     expect(one.repeat(0)).toBe(one);
     expect(one.repeat(3).toArray()).toEqual([1, 1, 1]);
     expect(Stream.of(1, 2, 3).repeat(2).toArray()).toEqual([1, 2, 3, 1, 2, 3]);
+
     sources.forEach((source) => {
       expect(source.repeat(0)).toBe(source);
       expect(source.repeat(2).toArray()).toEqual(
@@ -1193,6 +1368,10 @@ describe('Stream methods', () => {
     expect(Stream.empty<string>().minBy(comp, 1)).toBe(1);
     expect(Stream.of('a').minBy(comp)).toBe('a');
     expect(Stream.of('ab', 'c', 'def').minBy(comp)).toBe('c');
+
+    sources.forEach((source) => {
+      expect(source.minBy((v1, v2) => v2 - v1)).toBe(99);
+    });
   });
 
   it('max', () => {
@@ -1214,6 +1393,10 @@ describe('Stream methods', () => {
     expect(Stream.empty<string>().maxBy(comp, 1)).toBe(1);
     expect(Stream.of('a').maxBy(comp)).toBe('a');
     expect(Stream.of('ab', 'c', 'def').maxBy(comp)).toBe('def');
+
+    sources.forEach((source) => {
+      expect(source.minBy((v1, v2) => v2 - v1)).toBe(99);
+    });
   });
 
   it('intersperse', () => {
@@ -1230,6 +1413,7 @@ describe('Stream methods', () => {
 
   it('join', () => {
     expect(Stream.empty().join()).toBe('');
+    expect(Stream.empty().join({ start: '<', end: '>' })).toBe('<>');
     expect(Stream.empty().join({ start: '<', end: '>', ifEmpty: 'abc' })).toBe(
       'abc'
     );
@@ -1240,6 +1424,19 @@ describe('Stream methods', () => {
     );
     expect(Stream.of(1, 2, 3).join()).toBe('123');
     expect(Stream.of(1, 2, 3).join({ ifEmpty: 'abc' })).toBe('123');
+
+    expect(artificialEmpty.join()).toBe('');
+    expect(artificialEmpty.join({ start: '<', end: '>' })).toBe('<>');
+    expect(artificialEmpty.join({ start: '<', end: '>', ifEmpty: 'abc' })).toBe(
+      'abc'
+    );
+    expect(artificialEmpty.join({ start: '<', end: '>', sep: '-' })).toBe('<>');
+
+    sources.forEach((source) => {
+      expect(source.take(5).join({ start: '(', sep: ',', end: ')' })).toEqual(
+        '(0,1,2,3,4)'
+      );
+    });
   });
 
   it('mkGroup', () => {
@@ -1716,6 +1913,12 @@ describe('Stream methods', () => {
         collectorFalse: Reducer.join<number>({ sep: ',' }),
       })
     ).toEqual(['2', '1,3']);
+
+    sources.forEach((source) => {
+      const [left, right] = source.partition((v) => v % 2 === 0);
+      expect(left.length).toBe(50);
+      expect(right.length).toBe(50);
+    });
   });
 
   it('groupBy', () => {
@@ -1732,6 +1935,13 @@ describe('Stream methods', () => {
         [3, ['abc', 'def']],
       ])
     );
+
+    sources.forEach((source) => {
+      const result = source.groupBy((v) => v % 4);
+      for (let i = 0; i < 4; i++) {
+        expect(result.get(i)?.length).toBe(25);
+      }
+    });
   });
 
   it('groupBy collector', () => {

--- a/packages/stream/test/transformer.test.mts
+++ b/packages/stream/test/transformer.test.mts
@@ -74,4 +74,39 @@ describe('Collector', () => {
         .toArray()
     ).toEqual([1, 1, 2, 2, 3, 3]);
   });
+
+  it('filter', () => {
+    function isEven(v: number) {
+      return v % 2 === 0;
+    }
+
+    expect(
+      Stream.empty<number>().transform(Transformer.filter(isEven)).toArray()
+    ).toEqual([]);
+    expect(
+      Stream.of(1, 2, 3).transform(Transformer.filter(isEven)).toArray()
+    ).toEqual([2]);
+    expect(
+      Stream.of(1, 2, 3)
+        .transform(Transformer.filter(isEven, { negate: true }))
+        .toArray()
+    ).toEqual([1, 3]);
+  });
+
+  it('collect', () => {
+    expect(
+      Stream.empty<number>()
+        .transform(
+          Transformer.collect((v, _, skip) => (v % 2 === 0 ? String(v) : skip))
+        )
+        .toArray()
+    ).toEqual([]);
+    expect(
+      Stream.of(1, 2, 3, 4)
+        .transform(
+          Transformer.collect((v, _, skip) => (v % 2 === 0 ? String(v) : skip))
+        )
+        .toArray()
+    ).toEqual(['2', '4']);
+  });
 });

--- a/packages/stream/test/transformer.test.mts
+++ b/packages/stream/test/transformer.test.mts
@@ -60,4 +60,18 @@ describe('Collector', () => {
         .toArray()
     ).toEqual([1, 2, 3, 1, 3]);
   });
+
+  it('flatMap', () => {
+    expect(
+      Stream.empty<number>()
+        .transform(Transformer.flatMap((v) => [v, v]))
+        .toArray()
+    ).toEqual([]);
+
+    expect(
+      Stream.of(1, 2, 3)
+        .transform(Transformer.flatMap((v) => [v, v]))
+        .toArray()
+    ).toEqual([1, 1, 2, 2, 3, 3]);
+  });
 });


### PR DESCRIPTION
The `@rimbu/stream` package has been refactored with the following main differences:

* `filter...` and `find` methods now infer types when the predicate is a type guard
* More Reducers and AsyncReducers added like `partition`, `groupBy`, and `race`.
* Combining reducers has been made easier by extending the `reduce...` methods to accept reducer shapes.
* Reducers and AsyncReducers can now be halted in the initialisation phase
* Reducer and AsyncReducers now always require a lazy initialisation value
* More Transformers and AsyncTransformers have been added like `flatMap`, `flatZip`, and `filter`.
* Stream and AsyncStream have been extended with convenience methods based on the new reducers.
* Transformers and convenience methods have been added like `splitOn`, `splitOnSlice`.
