### PR TITLE
Feat/improve stream

### DIFF
--- a/deno_dist/actor/CHANGELOG.md
+++ b/deno_dist/actor/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.15.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/actor@0.14.0...@rimbu/actor@0.15.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [0.14.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/actor@0.13.1...@rimbu/actor@0.14.0) (2024-01-26)
 
 ### Bug Fixes

--- a/deno_dist/bimap/CHANGELOG.md
+++ b/deno_dist/bimap/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimap@2.0.0...@rimbu/bimap@2.0.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/bimap
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimap@1.1.1...@rimbu/bimap@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/bimultimap/CHANGELOG.md
+++ b/deno_dist/bimultimap/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimultimap@2.0.0...@rimbu/bimultimap@2.0.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/bimultimap
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimultimap@1.1.1...@rimbu/bimultimap@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/bimultimap/custom/implementation/context.ts
+++ b/deno_dist/bimultimap/custom/implementation/context.ts
@@ -109,7 +109,7 @@ export class BiMultiMapContext<
 
   readonly reducer = <K extends UK, V extends UV>(
     source?: StreamSource<readonly [K, V]>
-  ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']> => {
+  ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']> => {
     return Reducer.create(
       () =>
         undefined === source

--- a/deno_dist/bimultimap/custom/interface/base.ts
+++ b/deno_dist/bimultimap/custom/interface/base.ts
@@ -561,7 +561,7 @@ export namespace BiMultiMapBase {
      */
     reducer<K extends UK, V extends UV>(
       source?: StreamSource<readonly [K, V]>
-    ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']>;
+    ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']>;
   }
 
   export interface Context<

--- a/deno_dist/channel/CHANGELOG.md
+++ b/deno_dist/channel/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.3.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/channel@0.2.0...@rimbu/channel@0.3.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [0.2.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/channel@0.1.1...@rimbu/channel@0.2.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/collection-types/CHANGELOG.md
+++ b/deno_dist/collection-types/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/collection-types@2.0.0...@rimbu/collection-types@2.1.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/collection-types@1.1.1...@rimbu/collection-types@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/core/CHANGELOG.md
+++ b/deno_dist/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/core@2.0.0...@rimbu/core@2.0.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/core
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/core@1.1.3...@rimbu/core@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/graph/CHANGELOG.md
+++ b/deno_dist/graph/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/graph@2.0.0...@rimbu/graph@2.0.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/graph
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/graph@1.1.1...@rimbu/graph@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/hashed/CHANGELOG.md
+++ b/deno_dist/hashed/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/hashed@2.0.0...@rimbu/hashed@2.1.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/hashed@1.1.1...@rimbu/hashed@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/list/CHANGELOG.md
+++ b/deno_dist/list/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/list@2.0.0...@rimbu/list@2.1.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/list@1.1.1...@rimbu/list@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/multimap/CHANGELOG.md
+++ b/deno_dist/multimap/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/multimap@2.0.0...@rimbu/multimap@2.0.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/multimap
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/multimap@1.1.1...@rimbu/multimap@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/multimap/custom/implementation/base.ts
+++ b/deno_dist/multimap/custom/implementation/base.ts
@@ -721,7 +721,7 @@ export class MultiMapContext<
 
   readonly reducer = <K extends UK, V extends UV>(
     source?: StreamSource<readonly [K, V]>
-  ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']> => {
+  ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']> => {
     return Reducer.create(
       () =>
         undefined === source

--- a/deno_dist/multimap/custom/interface/base.ts
+++ b/deno_dist/multimap/custom/interface/base.ts
@@ -590,7 +590,7 @@ export namespace MultiMapBase {
      */
     reducer<K extends UK, V extends UV>(
       source?: StreamSource<readonly [K, V]>
-    ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']>;
+    ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']>;
   }
 
   /**

--- a/deno_dist/multiset/CHANGELOG.md
+++ b/deno_dist/multiset/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/multiset@2.0.0...@rimbu/multiset@2.1.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/multiset@1.1.1...@rimbu/multiset@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/ordered/CHANGELOG.md
+++ b/deno_dist/ordered/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/ordered@2.0.0...@rimbu/ordered@2.1.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/ordered@1.1.1...@rimbu/ordered@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/proximity/CHANGELOG.md
+++ b/deno_dist/proximity/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/proximity@2.0.0...@rimbu/proximity@2.0.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/proximity
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/proximity@1.1.1...@rimbu/proximity@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/reactor/CHANGELOG.md
+++ b/deno_dist/reactor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.14.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/reactor@0.14.0...@rimbu/reactor@0.14.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/reactor
+
 # [0.14.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/reactor@0.13.1...@rimbu/reactor@0.14.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/sorted/CHANGELOG.md
+++ b/deno_dist/sorted/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/sorted@2.0.0...@rimbu/sorted@2.1.0) (2024-02-14)
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/sorted@1.1.1...@rimbu/sorted@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/stream/CHANGELOG.md
+++ b/deno_dist/stream/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/stream@2.0.0...@rimbu/stream@2.1.0) (2024-02-14)
+
+### Bug Fixes
+
+- **stream:** extend test set and fix incorrect logic ([59065eb](https://github.com/rimbu-org/rimbu/commit/59065eb598e2908aed8c188aa5822d6990416c22))
+
+### Features
+
+- refactor Stream package, add more reducers and Stream methods ([6840c4f](https://github.com/rimbu-org/rimbu/commit/6840c4f28bf45767bd3019835b3abbaa51ccf311))
+- **stream:** add transformers and refactor stream ([7b32e14](https://github.com/rimbu-org/rimbu/commit/7b32e14b07e4d6670a192b06fc8ed0225a79b573))
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/stream@1.1.1...@rimbu/stream@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/stream/async-custom/async-stream-custom.ts
+++ b/deno_dist/stream/async-custom/async-stream-custom.ts
@@ -181,6 +181,26 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     return new AsyncFilterPureStream<T, A>(this, pred, args, negate);
   }
 
+  withOnly<F extends T>(values: F[]): AsyncStream<F> {
+    if (values.length <= 0) {
+      return this as any;
+    }
+
+    const set = new Set<T>(values);
+
+    return this.filterPure({ pred: (v) => set.has(v) });
+  }
+
+  without<F extends T>(values: F[]): any {
+    if (values.length <= 0) {
+      return this as any;
+    }
+
+    const set = new Set<T>(values);
+
+    return this.filterPure({ pred: (v) => set.has(v), negate: true });
+  }
+
   map<T2>(
     mapFun: (value: T, index: number) => MaybePromise<T2>
   ): AsyncStream<T2> {
@@ -757,7 +777,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
 
   groupBy<K, R>(
     valueToKey: (value: T, index: number) => MaybePromise<K>,
-    options: { collector?: AsyncReducer.Accept<[K, T], R> | undefined } = {}
+    options: {
+      collector?: AsyncReducer.Accept<readonly [K, T], R> | undefined;
+    } = {}
   ): Promise<R> {
     return (this as AsyncStream<T>).reduce(
       AsyncReducer.groupBy<T, K, R>(valueToKey, options as any)

--- a/deno_dist/stream/async/async-reducer.ts
+++ b/deno_dist/stream/async/async-reducer.ts
@@ -255,9 +255,9 @@ export namespace AsyncReducer {
      * // this reducer will double all input values before summing them
      * ```
      */
-    mapInput<I2>(
+    mapInput: <I2>(
       mapFun: (value: I2, index: number) => MaybePromise<I>
-    ): AsyncReducer<I2, O>;
+    ) => AsyncReducer<I2, O>;
     /**
      * Returns an `AsyncReducer` instance that converts its input values using given `flatMapFun` before passing them to the reducer.
      * @param flatMapFun - a potentially asynchronous function that returns am arbitrary number of new values to pass to the reducer based on the following inputs:<br/>
@@ -383,53 +383,6 @@ export namespace AsyncReducer {
       options?: { negate?: boolean | undefined }
     ): AsyncReducer<I, O>;
     /**
-     * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
-     * by the previous reducer.
-     * @typeparam O1 - the output type of the `nextReducer1` reducer
-     * @typeparam O2 - the output type of the `nextReducer2` reducer
-     * @typeparam O3 - the output type of the `nextReducer3` reducer
-     * @typeparam O4 - the output type of the `nextReducer4` reducer
-     * @typeparam O5 - the output type of the `nextReducer5` reducer
-     * @param nextReducer1 - the next reducer to apply to each output of this reducer.
-     * @param nextReducer2 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer3 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer4 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer5 - (optional) the next reducer to apply to each output of this reducer.
-     * @example
-     * ```ts
-     * AsyncStream
-     *  .from(Stream.of(1, 2, 3))
-     *  .reduce(
-     *    AsyncReducer.product
-     *      .pipe(AsyncReducer.sum)
-     *  )
-     * // => 9
-     * ```
-     */
-    pipe<O1>(nextReducer1: AsyncReducer.Accept<O, O1>): AsyncReducer<I, O1>;
-    pipe<O1, O2>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>
-    ): AsyncReducer<I, O2>;
-    pipe<O1, O2, O3>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>,
-      nextReducer3: AsyncReducer.Accept<O2, O3>
-    ): AsyncReducer<I, O3>;
-    pipe<O1, O2, O3, O4>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>,
-      nextReducer3: AsyncReducer.Accept<O2, O3>,
-      nextReducer4: AsyncReducer.Accept<O3, O4>
-    ): AsyncReducer<I, O4>;
-    pipe<O1, O2, O3, O4, O5>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>,
-      nextReducer3: AsyncReducer.Accept<O2, O3>,
-      nextReducer4: AsyncReducer.Accept<O3, O4>,
-      nextReducer5: AsyncReducer.Accept<O4, O5>
-    ): AsyncReducer<I, O5>;
-    /**
      * Returns a reducer that applies the given `nextReducers` sequentially after this reducer
      * has halted, and moving on to the next provided reducer until it is halted. Optionally, it provides the last output
      * value of the previous reducer.
@@ -438,52 +391,21 @@ export namespace AsyncReducer {
      * ```ts
      * const result = await AsyncStream.range({ amount: 6 })
      *  .reduce(
-     *    AsyncReducer.sum
+     *    Reducer.sum
      *      .takeInput(3)
      *      .chain(
-     *        v => v > 10 ? AsyncReducer.product : AsyncReducer.sum
+     *        v => v > 10 ? Reducer.product : Reducer.sum
      *      )
      *    )
      * console.log(result)
      * // => 21
      * ```
      */
-    chain<O1>(
-      nextReducers: [AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>]
-    ): AsyncReducer<I, O1>;
-    chain<O1, O2>(
-      nextReducer: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>
-      ]
+    chain<O2 extends O>(
+      nextReducers: AsyncStreamSource<
+        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O2]>
+      >
     ): AsyncReducer<I, O2>;
-    chain<O1, O2, O3>(
-      nextReducers: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>
-      ]
-    ): AsyncReducer<I, O3>;
-    chain<O1, O2, O3, O4>(
-      nextReducers: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>
-      ]
-    ): AsyncReducer<I, O4>;
-    chain<O1, O2, O3, O4, O5>(
-      nextReducers: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O5>, [O4]>
-      ]
-    ): AsyncReducer<I, O5>;
-    chain(
-      nextReducers: AsyncStreamSource<AsyncOptLazy<AsyncReducer<I, any>, [any]>>
-    ): AsyncReducer<I, unknown>;
 
     /**
      * Returns a promise that resolves to a 'runnable' instance of the current reducer specification. This instance maintains its own state
@@ -491,7 +413,7 @@ export namespace AsyncReducer {
      * retrieved when needed. The state is kept private.
      * @example
      * ```ts
-     * const reducer = AsyncReducer.sum.mapOutput(v => v * 2);
+     * const reducer = AsyncReducer.from(Reducer.sum.mapOutput(v => v * 2));
      * const instance = reducer.compile();
      * await instance.next(3);
      * await instance.next(5);
@@ -713,108 +635,72 @@ export namespace AsyncReducer {
       return this.takeInput(amount).dropInput(from);
     }
 
-    pipe<O2>(
-      ...nextReducers: AsyncReducer.Accept<O, O2>[]
+    chain<O2 extends O>(
+      nextReducers: AsyncStreamSource<
+        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O2]>
+      >
     ): AsyncReducer<I, O2> {
-      if (nextReducers.length <= 0) {
-        return this as any;
-      }
-
-      const [nextReducer, ...others] = nextReducers as AsyncReducer.Accept<
-        any,
-        any
-      >[];
-
-      if (others.length > 0) {
-        return (this.pipe(nextReducer).pipe as any)(...others);
-      }
-
       return AsyncReducer.create(
-        async (inithalt) => {
-          const thisInstance = await this.compile();
-          const nextInstance = await AsyncReducer.from(nextReducer).compile();
+        async (
+          initHalt
+        ): Promise<{
+          activeInstance: AsyncReducer.Instance<I, O2>;
+          iterator: AsyncFastIterator<
+            AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O2]>
+          >;
+        }> => {
+          const iterator =
+            fromAsyncStreamSource(nextReducers)[Symbol.asyncIterator]();
+          let activeInstance = (await this.compile()) as AsyncReducer.Instance<
+            I,
+            O2
+          >;
 
-          if (thisInstance.halted || nextInstance.halted) {
-            inithalt();
+          if (undefined !== activeInstance && activeInstance.halted) {
+            let output = await activeInstance.getOutput();
+
+            do {
+              const creator = await iterator.fastNext();
+
+              if (undefined === creator) {
+                initHalt();
+
+                return {
+                  activeInstance,
+                  iterator,
+                };
+              }
+              const nextReducer = await AsyncOptLazy.toMaybePromise(
+                creator,
+                output
+              );
+
+              activeInstance = await AsyncReducer.from(nextReducer).compile();
+              output = await activeInstance.getOutput();
+            } while (activeInstance.halted);
           }
 
           return {
-            thisInstance,
-            nextInstance,
+            activeInstance,
+            iterator,
           };
         },
         async (state, next, index, halt) => {
-          const { thisInstance, nextInstance } = state;
-
-          await thisInstance.next(next);
-          await nextInstance.next(await thisInstance.getOutput());
-
-          if (thisInstance.halted || nextInstance.halted) {
-            halt();
-          }
-
-          return state;
-        },
-        async (state, index, halted) => {
-          if (halted && index === 0) {
-            await state.nextInstance.next(await state.thisInstance.getOutput());
-          }
-
-          return state.nextInstance.getOutput();
-        },
-        async (state, err) => {
-          await Promise.all([
-            state.thisInstance.onClose(err),
-            state.nextInstance.onClose(err),
-          ]);
-        }
-      );
-    }
-
-    chain(
-      nextReducers: AsyncStreamSource<
-        AsyncOptLazy<AsyncReducer.Accept<I, any>, [any]>
-      >
-    ): AsyncReducer<I, O> {
-      return AsyncReducer.create(
-        async () => ({
-          activeInstance: (await this.compile()) as AsyncReducer.Instance<I, O>,
-          iterator: fromAsyncStreamSource(nextReducers)[Symbol.asyncIterator](),
-        }),
-        async (state, next, index, halt) => {
-          const done = Symbol();
-
-          while (state.activeInstance.halted) {
-            const nextItem = await state.iterator.fastNext(done);
-
-            if (done === nextItem) {
-              halt();
-              return state;
-            }
-
-            const nextReducer = await AsyncOptLazy.toMaybePromise(
-              nextItem,
-              await state.activeInstance.getOutput()
-            );
-
-            state.activeInstance = await AsyncReducer.from(
-              nextReducer
-            ).compile();
-          }
-
           await state.activeInstance.next(next);
 
           while (state.activeInstance.halted) {
-            const nextItem = await state.iterator.fastNext(done);
+            const output = await state.activeInstance.getOutput();
+            const creator = await state.iterator.fastNext();
 
-            if (done === nextItem) {
+            if (undefined === creator) {
               halt();
+
               return state;
             }
 
             const nextReducer = await AsyncOptLazy.toMaybePromise(
-              nextItem,
-              await state.activeInstance.getOutput()
+              creator,
+              output
             );
 
             state.activeInstance = await AsyncReducer.from(
@@ -824,8 +710,7 @@ export namespace AsyncReducer {
 
           return state;
         },
-        (state) => state.activeInstance.getOutput(),
-        (state, err) => state.activeInstance.onClose(err)
+        (state) => state.activeInstance.getOutput()
       );
     }
 
@@ -1546,7 +1431,8 @@ export namespace AsyncReducer {
   ): AsyncReducer<T, boolean> {
     const { eq, amount = 1 } = options;
 
-    return endsWithSlice(slice, { eq }).pipe(
+    return AsyncReducer.pipe(
+      endsWithSlice(slice, { eq }),
       Reducer.contains(true, { amount })
     );
   }
@@ -1639,10 +1525,10 @@ export namespace AsyncReducer {
    * ```
    */
   export const groupBy: {
-    <T, K, R>(
+    <T, K, R, T2 extends readonly [K, T] = [K, T]>(
       valueToKey: (value: T, index: number) => MaybePromise<K>,
       options: {
-        collector: AsyncReducer.Accept<[K, T], R>;
+        collector: AsyncReducer.Accept<[K, T] | T2, R>;
       }
     ): AsyncReducer<T, R>;
     <T, K>(
@@ -1654,11 +1540,14 @@ export namespace AsyncReducer {
   } = <T, K, R>(
     valueToKey: (value: T, index: number) => MaybePromise<K>,
     options: {
-      collector?: AsyncReducer.Accept<[K, T], R> | undefined;
+      collector?: AsyncReducer.Accept<readonly [K, T], R> | undefined;
     } = {}
   ): AsyncReducer<T, R> => {
     const {
-      collector = Reducer.toJSMultiMap() as AsyncReducer.Accept<[K, T], R>,
+      collector = Reducer.toJSMultiMap() as AsyncReducer.Accept<
+        readonly [K, T],
+        R
+      >,
     } = options;
 
     return AsyncReducer.create(
@@ -1740,8 +1629,8 @@ export namespace AsyncReducer {
    * Type defining the allowed shape of async reducer combinations.
    * @typeparam T - the input type
    */
-  export type CombineShape<T = unknown> =
-    | AsyncReducer.Accept<T, unknown>
+  export type CombineShape<T> =
+    | AsyncReducer.Accept<T, any>
     | AsyncReducer.CombineShape<T>[]
     | { [key: string]: AsyncReducer.CombineShape<T> };
 
@@ -1750,19 +1639,19 @@ export namespace AsyncReducer {
    * @typeparam S - the reducer combination shape
    */
   export type CombineResult<S extends AsyncReducer.CombineShape<any>> =
-    /* tuple */ S extends readonly AsyncReducer.CombineShape[]
+    /* tuple */ S extends readonly AsyncReducer.CombineShape<any>[]
       ? /* is array? */ 0 extends S['length']
         ? AsyncReducer.CombineResult<S[number]>[]
         : /* only tuples */ {
-            [K in keyof S]: S[K] extends AsyncReducer.CombineShape
+            [K in keyof S]: S[K] extends AsyncReducer.CombineShape<any>
               ? AsyncReducer.CombineResult<S[K]>
               : never;
           }
       : /* plain object */ S extends {
-          [key: string]: AsyncReducer.CombineShape;
+          [key: string]: AsyncReducer.CombineShape<any>;
         }
       ? { [K in keyof S]: AsyncReducer.CombineResult<S[K]> }
-      : /* simple reducer */ S extends AsyncReducer.Accept<unknown, infer R>
+      : /* simple reducer */ S extends AsyncReducer.Accept<any, infer R>
       ? R
       : never;
 
@@ -1824,4 +1713,114 @@ export namespace AsyncReducer {
 
     throw new AsyncReducer.InvalidCombineShapeError();
   }
+
+  /**
+   * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
+   * by the previous reducer.
+   * @typeparam I - the input type of the `reducer1` reducer
+   * @typeparam O1 - the output type of the `reducer1` reducer
+   * @typeparam O2 - the output type of the `reducer2` reducer
+   * @typeparam O3 - the output type of the `reducer3` reducer
+   * @typeparam O4 - the output type of the `reducer4` reducer
+   * @typeparam O5 - the output type of the `reducer5` reducer
+   * @param reducer1 - the next reducer to apply to each output of this reducer.
+   * @param reducer2 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer3 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer4 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer5 - (optional) the next reducer to apply to each output of this reducer.
+   * @example
+   * ```ts
+   * AsyncStream
+   *  .from(Stream.of(1, 2, 3))
+   *  .reduce(
+   *    AsyncReducer.pipe(Reducer.product, Reducer.sum)
+   *  )
+   * // => 9
+   * ```
+   */
+  export const pipe: {
+    <I, O1, O2>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>
+    ): AsyncReducer<I, O2>;
+    <I, O1, O2, O3>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>,
+      reducer3: AsyncReducer.Accept<O2, O3>
+    ): AsyncReducer<I, O3>;
+    <I, O1, O2, O3, O4>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>,
+      reducer3: AsyncReducer.Accept<O2, O3>,
+      reducer4: AsyncReducer.Accept<O2, O4>
+    ): AsyncReducer<I, O4>;
+    <I, O1, O2, O3, O4, O5>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>,
+      reducer3: AsyncReducer.Accept<O2, O3>,
+      reducer4: AsyncReducer.Accept<O2, O4>,
+      reducer5: AsyncReducer.Accept<O2, O5>
+    ): AsyncReducer<I, O5>;
+  } = (...nextReducers: AsyncReducer.Accept<any, any>[]): any => {
+    if (nextReducers.length < 2) {
+      RimbuError.throwInvalidUsageError(
+        'Reducer.pipe should have at least two arguments'
+      );
+    }
+
+    const [current, next, ...others] = nextReducers as AsyncReducer.Accept<
+      any,
+      any
+    >[];
+
+    if (others.length > 0) {
+      return AsyncReducer.pipe(
+        current,
+        (AsyncReducer.pipe as any)(next, ...others)
+      );
+    }
+
+    return AsyncReducer.create(
+      async (inithalt) => {
+        const currentInstance = await AsyncReducer.from(current).compile();
+        const nextInstance = await AsyncReducer.from(next).compile();
+
+        if (currentInstance.halted || nextInstance.halted) {
+          inithalt();
+        }
+
+        return {
+          currentInstance,
+          nextInstance,
+        };
+      },
+      async (state, next, index, halt) => {
+        const { currentInstance, nextInstance } = state;
+
+        await currentInstance.next(next);
+        await nextInstance.next(await currentInstance.getOutput());
+
+        if (currentInstance.halted || nextInstance.halted) {
+          halt();
+        }
+
+        return state;
+      },
+      async (state, index, halted) => {
+        if (halted && index === 0) {
+          await state.nextInstance.next(
+            await state.currentInstance.getOutput()
+          );
+        }
+
+        return state.nextInstance.getOutput();
+      },
+      async (state, err) => {
+        await Promise.all([
+          state.currentInstance.onClose(err),
+          state.nextInstance.onClose(err),
+        ]);
+      }
+    );
+  };
 }

--- a/deno_dist/stream/async/async-transformer.ts
+++ b/deno_dist/stream/async/async-transformer.ts
@@ -93,7 +93,7 @@ export namespace AsyncTransformer {
       skipAmount?: number | undefined;
       collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
-  ) => {
+  ): AsyncTransformer<T, R> => {
     const {
       skipAmount = windowSize,
       collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
@@ -101,7 +101,7 @@ export namespace AsyncTransformer {
 
     return AsyncReducer.create<
       T,
-      AsyncStream<R>,
+      AsyncStreamSource<R>,
       Set<AsyncReducer.Instance<T, R>>
     >(
       () => new Set(),
@@ -301,7 +301,11 @@ export namespace AsyncTransformer {
       collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
     } = options;
 
-    return AsyncReducer.create(
+    return AsyncReducer.create<
+      T,
+      AsyncStreamSource<R>,
+      { collection: AsyncReducer.Instance<T, R>; done: boolean }
+    >(
       async () => ({
         collection: await AsyncReducer.from(collector).compile(),
         done: false,
@@ -352,7 +356,11 @@ export namespace AsyncTransformer {
       collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
     } = options;
 
-    return AsyncReducer.create(
+    return AsyncReducer.create<
+      T,
+      AsyncStreamSource<R>,
+      { collection: AsyncReducer.Instance<T, R>; done: boolean }
+    >(
       async () => ({
         collection: await AsyncReducer.from(collector).compile(),
         done: false,
@@ -402,7 +410,7 @@ export namespace AsyncTransformer {
 
     return AsyncReducer.create<
       T,
-      AsyncStream<R>,
+      AsyncStreamSource<R>,
       {
         done: boolean;
         instances: Map<AsyncReducer.Instance<T, boolean>, number>;

--- a/deno_dist/stream/async/index.ts
+++ b/deno_dist/stream/async/index.ts
@@ -11,7 +11,7 @@ export * from './async-fast-iterator.ts';
 export * from './async-fast-iterable.ts';
 export * from './async-streamable.ts';
 
-export * from './interface.ts';
+export * from './async-stream.ts';
 
 export * from './async-reducer.ts';
 export * from './async-transformer.ts';

--- a/deno_dist/stream/async/interface.ts
+++ b/deno_dist/stream/async/interface.ts
@@ -768,7 +768,7 @@ export interface AsyncStream<T>
    * @param otherwise - (default: undefined) the value to return if the Stream is empty
    * @example
    * ```ts
-   * await AsyncStream.of(5, 1, 3).max()         // => 1
+   * await AsyncStream.of(5, 1, 3).max()         // => 5
    * await AsyncStream.empty<number>().max()     // => undefined
    * await AsyncStream.empty<number>().max('a')  // => 'a'
    * ```
@@ -1421,7 +1421,7 @@ export namespace AsyncStream {
      * Returns the maximum element of the AsyncStream according to a default compare function.
      * @example
      * ```ts
-     * await AsyncStream.of(5, 1, 3).max()         // => 1
+     * await AsyncStream.of(5, 1, 3).max()         // => 5
      * ```
      * @note O(N)
      */

--- a/deno_dist/stream/main/index.ts
+++ b/deno_dist/stream/main/index.ts
@@ -14,7 +14,7 @@ export * from './fast-iterable.ts';
 export * from './streamable.ts';
 export * from './stream-source.ts';
 
-export * from './interface.ts';
+export * from './stream.ts';
 
 export * from './reducer.ts';
 export * from './transformer.ts';

--- a/deno_dist/stream/main/interface.ts
+++ b/deno_dist/stream/main/interface.ts
@@ -739,7 +739,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @param otherwise - (default: undefined) the value to return if the Stream is empty
    * @example
    * ```ts
-   * Stream.of(5, 1, 3).max()         // => 1
+   * Stream.of(5, 1, 3).max()         // => 5
    * Stream.empty<number>().max()     // => undefined
    * Stream.empty<number>().max('a')  // => 'a'
    * ```
@@ -1363,7 +1363,7 @@ export namespace Stream {
      * Returns the maximum element of the Stream according to a default compare function.
      * @example
      * ```ts
-     * Stream.of(5, 1, 3).max()         // => 1
+     * Stream.of(5, 1, 3).max()         // => 5
      * ```
      * @note O(N)
      */

--- a/deno_dist/stream/main/reducer.ts
+++ b/deno_dist/stream/main/reducer.ts
@@ -194,7 +194,7 @@ export namespace Reducer {
      * // this reducer will double all input values before summing them
      * ```
      */
-    mapInput<I2>(mapFun: (value: I2, index: number) => I): Reducer<I2, O>;
+    mapInput: <I2>(mapFun: (value: I2, index: number) => I) => Reducer<I2, O>;
     /**
      * Returns a `Reducer` instance that converts each output value from some source reducer into an arbitrary number of output values
      * using given `flatMapFun` before passing them to this reducer.
@@ -292,55 +292,8 @@ export namespace Reducer {
       options?: { negate?: boolean }
     ): Reducer<I, O>;
     /**
-     * Returns a `Reducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
-     * by the previous reducer.
-     * @typeparam O1 - the output type of the `nextReducer1` reducer
-     * @typeparam O2 - the output type of the `nextReducer2` reducer
-     * @typeparam O3 - the output type of the `nextReducer3` reducer
-     * @typeparam O4 - the output type of the `nextReducer4` reducer
-     * @typeparam O5 - the output type of the `nextReducer5` reducer
-     * @param nextReducer1 - the next reducer to apply to each output of this reducer.
-     * @param nextReducer2 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer3 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer4 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer5 - (optional) the next reducer to apply to each output of this reducer.
-     * @example
-     * ```ts
-     * Stream.of(1, 2, 3)
-     *  .reduce(
-     *    Reducer.product
-     *      .pipe(Reducer.sum)
-     *    )
-     * // => 9
-     * ```
-     */
-    pipe<O1>(nextReducer1: Reducer<O, O1>): Reducer<I, O1>;
-    pipe<O1, O2>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>
-    ): Reducer<I, O2>;
-    pipe<O1, O2, O3>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>,
-      nextReducer3: Reducer<O2, O3>
-    ): Reducer<I, O3>;
-    pipe<O1, O2, O3, O4>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>,
-      nextReducer3: Reducer<O2, O3>,
-      nextReducer4: Reducer<O3, O4>
-    ): Reducer<I, O4>;
-    pipe<O1, O2, O3, O4, O5>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>,
-      nextReducer3: Reducer<O2, O3>,
-      nextReducer4: Reducer<O3, O4>,
-      nextReducer5: Reducer<O4, O5>
-    ): Reducer<I, O5>;
-    /**
-     * Returns a reducer that applies the given `nextReducers` sequentially after this reducer
-     * has halted, and moving on to the next provided reducer until it is halted. Optionally, it provides the last output
-     * value of the previous reducer.
+     * Returns a reducer that applies this reducer and then the `nextReducers` sequentially on halting of each reducer.
+     * It provides the last output value of the active reducer.
      * @param nextReducers - an number of reducers consuming and producing the same types as the current reducer.
      * @example
      * ```ts
@@ -356,40 +309,9 @@ export namespace Reducer {
      * // => 21
      * ```
      */
-    chain<O1>(nextReducers: [OptLazy<Reducer<I, O1>, [O]>]): Reducer<I, O1>;
-    chain<O1, O2>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>
-      ]
+    chain<O2 extends O>(
+      nextReducers: StreamSource<OptLazy<Reducer<I, O2>, [O2]>>
     ): Reducer<I, O2>;
-    chain<O1, O2, O3>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>,
-        OptLazy<Reducer<I, O3>, [O2]>
-      ]
-    ): Reducer<I, O3>;
-    chain<O1, O2, O3, O4>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>,
-        OptLazy<Reducer<I, O3>, [O2]>,
-        OptLazy<Reducer<I, O4>, [O3]>
-      ]
-    ): Reducer<I, O4>;
-    chain<O1, O2, O3, O4, O5>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>,
-        OptLazy<Reducer<I, O3>, [O2]>,
-        OptLazy<Reducer<I, O4>, [O3]>,
-        OptLazy<Reducer<I, O5>, [O4]>
-      ]
-    ): Reducer<I, O5>;
-    chain(
-      nextReducers: StreamSource<OptLazy<Reducer<I, any>, [any]>>
-    ): Reducer<I, unknown>;
     /**
      * Returns a 'runnable' instance of the current reducer specification. This instance maintains its own state
      * and indices, so that the instance only needs to be provided the input values, and output values can be
@@ -423,10 +345,10 @@ export namespace Reducer {
     filterInput(
       pred: (value: I, index: number, halt: () => void) => boolean,
       options: { negate?: boolean | undefined } = {}
-    ): Reducer<never, O> {
+    ): any {
       const { negate = false } = options;
 
-      return create(
+      return create<I, O, Reducer.Instance<I, O>>(
         () => this.compile(),
         (state, elem, index, halt) => {
           if (pred(elem, index, halt) !== negate) {
@@ -591,96 +513,57 @@ export namespace Reducer {
       return this.takeInput(amount).dropInput(from);
     }
 
-    pipe<O2>(...nextReducers: Reducer<O, O2>[]): Reducer<I, O2> {
-      if (nextReducers.length <= 0) {
-        return this as any;
-      }
-
-      const [nextReducer, ...others] = nextReducers as Reducer<any, any>[];
-
-      if (others.length > 0) {
-        return (this.pipe(nextReducer).pipe as any)(...others);
-      }
-
+    chain<O2 extends O>(
+      nextReducers: StreamSource<OptLazy<Reducer<I, O2>, [O2]>>
+    ): Reducer<I, O2> {
       return Reducer.create(
-        (initHalt) => {
-          const thisInstance = this.compile();
-          const nextInstance = nextReducer.compile();
+        (
+          initHalt
+        ): {
+          activeInstance: Reducer.Instance<I, O2>;
+          iterator: FastIterator<OptLazy<Reducer<I, O2>, [O2]>>;
+        } => {
+          const iterator = Stream.from(nextReducers)[Symbol.iterator]();
+          let activeInstance = this.compile() as Reducer.Instance<I, O2>;
 
-          if (thisInstance.halted || nextInstance.halted) {
-            initHalt();
+          if (undefined !== activeInstance && activeInstance.halted) {
+            let output = activeInstance.getOutput();
+
+            do {
+              const creator = iterator.fastNext();
+
+              if (undefined === creator) {
+                initHalt();
+
+                return {
+                  activeInstance,
+                  iterator,
+                };
+              }
+              activeInstance = OptLazy(creator, output).compile();
+              output = activeInstance.getOutput();
+            } while (activeInstance.halted);
           }
 
           return {
-            thisInstance,
-            nextInstance,
+            activeInstance,
+            iterator,
           };
         },
         (state, next, index, halt) => {
-          const { thisInstance, nextInstance } = state;
-
-          thisInstance.next(next);
-          nextInstance.next(thisInstance.getOutput());
-
-          if (thisInstance.halted || nextInstance.halted) {
-            halt();
-          }
-
-          return state;
-        },
-        (state, index, halted) => {
-          if (halted && index === 0) {
-            state.nextInstance.next(state.thisInstance.getOutput());
-          }
-
-          return state.nextInstance.getOutput();
-        }
-      );
-    }
-
-    chain(
-      nextReducers: StreamSource<OptLazy<Reducer<I, any>, [any]>>
-    ): Reducer<I, O> {
-      return Reducer.create(
-        () => ({
-          activeInstance: this.compile() as Reducer.Instance<I, O>,
-          iterator: Stream.from(nextReducers)[Symbol.iterator](),
-        }),
-        (state, next, index, halt) => {
-          const done = Symbol();
-
-          while (state.activeInstance.halted) {
-            const nextItem = state.iterator.fastNext(done);
-
-            if (done === nextItem) {
-              halt();
-              return state;
-            }
-
-            const nextReducer = OptLazy(
-              nextItem,
-              state.activeInstance.getOutput()
-            );
-
-            state.activeInstance = nextReducer.compile();
-          }
-
           state.activeInstance.next(next);
 
           while (state.activeInstance.halted) {
-            const nextItem = state.iterator.fastNext(done);
+            const output = state.activeInstance.getOutput();
+            const creator = state.iterator.fastNext();
 
-            if (done === nextItem) {
+            if (undefined === creator) {
               halt();
+
               return state;
             }
 
-            const nextReducer = OptLazy(
-              nextItem,
-              state.activeInstance.getOutput()
-            );
-
-            state.activeInstance = nextReducer.compile();
+            state.activeInstance = OptLazy(creator, output).compile();
           }
 
           return state;
@@ -1271,11 +1154,11 @@ export namespace Reducer {
    * // => true
    * ```
    */
-  export function contains<T>(
-    elem: T,
+  export function contains<T, T2 extends T = T>(
+    elem: T2,
     options: {
       amount?: number;
-      eq?: Eq<T>;
+      eq?: Eq<T | T2>;
       negate?: boolean;
     } = {}
   ): Reducer<T, boolean> {
@@ -1439,7 +1322,8 @@ export namespace Reducer {
   ): Reducer<T, boolean> {
     const { eq, amount = 1 } = options;
 
-    return endsWithSlice(slice, { eq }).pipe(
+    return Reducer.pipe(
+      endsWithSlice(slice, { eq }),
       Reducer.contains(true, { amount })
     );
   }
@@ -1587,17 +1471,18 @@ export namespace Reducer {
     ): Reducer<T, [true: T[], false: T[]]>;
   } = <T, RT, RF = RT>(
     pred: (value: T, index: number) => boolean,
-    options: {
-      collectorTrue?: Reducer<T, RT> | undefined;
-      collectorFalse?: Reducer<T, RF> | undefined;
-    } = {}
-  ): Reducer<T, [true: RT, false: RF]> => {
-    const {
-      collectorTrue = Reducer.toArray() as Reducer<T, RT>,
-      collectorFalse = Reducer.toArray() as Reducer<T, RF>,
-    } = options;
+    options: any = {}
+  ): any => {
+    const collectorTrue: Reducer<T, RT> =
+      options.collectorTrue ?? Reducer.toArray();
+    const collectorFalse: Reducer<T, RF> =
+      options.collectorFalse ?? Reducer.toArray();
 
-    return Reducer.create(
+    return Reducer.create<
+      T,
+      [RT, RF],
+      [Reducer.Instance<T, RT>, Reducer.Instance<T, RF>]
+    >(
       () => [collectorTrue.compile(), collectorFalse.compile()],
       (state, value, index) => {
         const instanceIndex = pred(value, index) ? 0 : 1;
@@ -1627,10 +1512,10 @@ export namespace Reducer {
    * ```
    */
   export const groupBy: {
-    <T, K, R>(
+    <T, K, R, T2 extends readonly [K, T] = [K, T]>(
       valueToKey: (value: T, index: number) => K,
       options: {
-        collector: Reducer<[K, T], R>;
+        collector: Reducer<[K, T] | T2, R>;
       }
     ): Reducer<T, R>;
     <T, K>(
@@ -1642,11 +1527,12 @@ export namespace Reducer {
   } = <T, K, R>(
     valueToKey: (value: T, index: number) => K,
     options: {
-      collector?: Reducer<[K, T], R> | undefined;
+      collector?: Reducer<readonly [K, T], R> | undefined;
     } = {}
   ): Reducer<T, R> => {
-    const { collector = Reducer.toJSMultiMap() as Reducer<[K, T], R> } =
-      options;
+    const {
+      collector = Reducer.toJSMultiMap() as Reducer<readonly [K, T], R>,
+    } = options;
 
     return Reducer.create(
       () => collector.compile(),
@@ -1759,7 +1645,7 @@ export namespace Reducer {
    * // Map { 1 => 'a', 2 => 'b' }
    * ```
    */
-  export function toJSMap<K, V>(): Reducer<[K, V], Map<K, V>> {
+  export function toJSMap<K, V>(): Reducer<readonly [K, V], Map<K, V>> {
     return create(
       (): Map<K, V> => new Map(),
       (state, next): Map<K, V> => {
@@ -1781,7 +1667,7 @@ export namespace Reducer {
    * // Map { 1 => 'a', 2 => 'b' }
    * ```
    */
-  export function toJSMultiMap<K, V>(): Reducer<[K, V], Map<K, V[]>> {
+  export function toJSMultiMap<K, V>(): Reducer<readonly [K, V], Map<K, V[]>> {
     return create(
       (): Map<K, V[]> => new Map(),
       (state, [key, value]) => {
@@ -1847,27 +1733,29 @@ export namespace Reducer {
    * Type defining the allowed shape of reducer combinations.
    * @typeparam T - the input type
    */
-  export type CombineShape<T = unknown> =
-    | Reducer<T, unknown>
-    | CombineShape<T>[]
-    | { [key: string]: CombineShape<T> };
+  export type CombineShape<T> =
+    | Reducer<T, any>
+    | Reducer.CombineShape<T>[]
+    | { [key: string]: Reducer.CombineShape<T> };
 
   /**
    * Type defining the result type of a reducer combination for a given shape.
    * @typeparam S - the reducer combination shape
    */
-  export type CombineResult<S extends CombineShape> =
-    /* tuple */ S extends readonly CombineShape[]
+  export type CombineResult<S extends Reducer.CombineShape<any>> =
+    /* tuple */ S extends readonly Reducer.CombineShape<any>[]
       ? /* is array? */ 0 extends S['length']
-        ? CombineResult<S[number]>[]
+        ? Reducer.CombineResult<S[number]>[]
         : /* only tuples */ {
-            [K in keyof S]: S[K] extends CombineShape
-              ? CombineResult<S[K]>
+            [K in keyof S]: S[K] extends Reducer.CombineShape<any>
+              ? Reducer.CombineResult<S[K]>
               : never;
           }
-      : /* plain object */ S extends { [key: string]: CombineShape }
-      ? { [K in keyof S]: CombineResult<S[K]> }
-      : /* simple reducer */ S extends Reducer<unknown, infer R>
+      : /* plain object */ S extends {
+          [key: string]: Reducer.CombineShape<any>;
+        }
+      ? { [K in keyof S]: Reducer.CombineResult<S[K]> }
+      : /* simple reducer */ S extends Reducer<any, infer R>
       ? R
       : never;
 
@@ -1920,4 +1808,99 @@ export namespace Reducer {
 
     throw new Reducer.InvalidCombineShapeError();
   }
+
+  /**
+   * Returns a `Reducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
+   * by the previous reducer.
+   * @typeparam I - the input type of the `reducer1` reducer
+   * @typeparam O1 - the output type of the `reducer1` reducer
+   * @typeparam O2 - the output type of the `reducer2` reducer
+   * @typeparam O3 - the output type of the `reducer3` reducer
+   * @typeparam O4 - the output type of the `reducer4` reducer
+   * @typeparam O5 - the output type of the `reducer5` reducer
+   * @param reducer1 - the next reducer to apply to each output of this reducer.
+   * @param reducer2 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer3 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer4 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer5 - (optional) the next reducer to apply to each output of this reducer.
+   * @example
+   * ```ts
+   * Stream.of(1, 2, 3)
+   *  .reduce(
+   *    Reducer.pipe(Reducer.product, Reducer.sum)
+   *  )
+   * // => 9
+   * ```
+   */
+  export const pipe: {
+    <I, O1, O2>(reducer1: Reducer<I, O1>, reducer2: Reducer<O1, O2>): Reducer<
+      I,
+      O2
+    >;
+    <I, O1, O2, O3>(
+      reducer1: Reducer<I, O1>,
+      reducer2: Reducer<O1, O2>,
+      reducer3: Reducer<O2, O3>
+    ): Reducer<I, O3>;
+    <I, O1, O2, O3, O4>(
+      reducer1: Reducer<I, O1>,
+      reducer2: Reducer<O1, O2>,
+      reducer3: Reducer<O2, O3>,
+      reducer4: Reducer<O2, O4>
+    ): Reducer<I, O4>;
+    <I, O1, O2, O3, O4, O5>(
+      reducer1: Reducer<I, O1>,
+      reducer2: Reducer<O1, O2>,
+      reducer3: Reducer<O2, O3>,
+      reducer4: Reducer<O2, O4>,
+      reducer5: Reducer<O2, O5>
+    ): Reducer<I, O5>;
+  } = (...nextReducers: Reducer<any, any>[]): any => {
+    if (nextReducers.length < 2) {
+      RimbuError.throwInvalidUsageError(
+        'Reducer.pipe should have at least two arguments'
+      );
+    }
+
+    const [current, next, ...others] = nextReducers as Reducer<any, any>[];
+
+    if (others.length > 0) {
+      return Reducer.pipe(current, (Reducer.pipe as any)(next, ...others));
+    }
+
+    return Reducer.create(
+      (inithalt) => {
+        const currentInstance = current.compile();
+        const nextInstance = next.compile();
+
+        if (currentInstance.halted || nextInstance.halted) {
+          inithalt();
+        }
+
+        return {
+          currentInstance,
+          nextInstance,
+        };
+      },
+      (state, next, index, halt) => {
+        const { currentInstance, nextInstance } = state;
+
+        currentInstance.next(next);
+        nextInstance.next(currentInstance.getOutput());
+
+        if (currentInstance.halted || nextInstance.halted) {
+          halt();
+        }
+
+        return state;
+      },
+      (state, index, halted) => {
+        if (halted && index === 0) {
+          state.nextInstance.next(state.currentInstance.getOutput());
+        }
+
+        return state.nextInstance.getOutput();
+      }
+    );
+  };
 }

--- a/deno_dist/stream/main/stream.ts
+++ b/deno_dist/stream/main/stream.ts
@@ -234,7 +234,9 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [[1, 2, 3], [4, 5, 6]]
    * ```
    */
-  transform<R>(transformer: Transformer<T, R>): Stream<R>;
+  transform<R, T2 extends T = T>(
+    transformer: Transformer<T | T2, R>
+  ): Stream<R>;
   /**
    * Returns a Stream containing only those elements from this Stream for which the given `pred` function returns true.
    * @param pred - a function taking an element and its index, and returning true if the element should be included in the resulting Stream.
@@ -296,6 +298,20 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
     },
     ...args: A
   ): Stream<T>;
+  /**
+   * Returns a Stream containing only those elements that are in the given `values` array.
+   * @typeparam F - a subtype of T to indicate the resulting element type
+   * @param values - an array of values to include
+   */
+  withOnly<F extends T>(values: F[]): Stream<F>;
+  /**
+   * Returns a Stream containing all elements except the elements in the given `values` array.
+   * @typeparam F - a subtype of T to indicate the resulting element type
+   * @param values - an array of values to exclude
+   */
+  without<F extends T>(
+    values: F[]
+  ): Stream<T extends Exclude<T, F> ? T : Exclude<T, F>>;
   /**
    * Returns a Stream containing the resulting elements from applying the given `collectFun` to each element in this Stream.
    * @typeparam R - the result element type
@@ -830,9 +846,9 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * ```
    * @note O(1)
    */
-  splitWhere<R>(
+  splitWhere<R, T2 extends T = T>(
     pred: (value: T, index: number) => boolean,
-    options: { negate?: boolean | undefined; collector: Reducer<T, R> }
+    options: { negate?: boolean | undefined; collector: Reducer<T | T2, R> }
   ): Stream<R>;
   splitWhere(
     pred: (value: T, index: number) => boolean,
@@ -854,13 +870,13 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @note O(1)
    */
   splitOn<R, T2 extends T = T>(
-    sepElem: T2,
+    sepElem: T,
     options: {
-      eq?: Eq<T2> | undefined;
+      eq?: Eq<T> | undefined;
       negate?: boolean | undefined;
-      collector: Reducer<T, R>;
+      collector: Reducer<T | T2, R>;
     }
-  ): Stream<T[]>;
+  ): Stream<R>;
   splitOn(
     sepElem: T,
     options?: {
@@ -884,11 +900,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @note O(1)
    */
   splitOnSlice<R, T2 extends T = T>(
-    sepSlice: StreamSource<T & T2>,
-    options: { eq?: Eq<T> | undefined; collector: Reducer<T & T2, R> }
+    sepSlice: StreamSource<T>,
+    options: { eq?: Eq<T> | undefined; collector: Reducer<T | T2, R> }
   ): Stream<R>;
-  splitOnSlice<T2 extends T = T>(
-    sepSlice: StreamSource<T & T2>,
+  splitOnSlice(
+    sepSlice: StreamSource<T>,
     options?: { eq?: Eq<T> | undefined; collector?: undefined }
   ): Stream<T[]>;
   /**
@@ -925,11 +941,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [Set(1, 2), Set(3, 4)]
    * ```
    */
-  window<R>(
+  window<R, T2 extends T = T>(
     windowSize: number,
     options: {
       skipAmount?: number | undefined;
-      collector: Reducer<T, R>;
+      collector: Reducer<T | T2, R>;
     }
   ): Stream<R>;
   window(
@@ -963,11 +979,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
       collectorFalse?: undefined;
     }
   ): [true: T2[], false: Exclude<T, T2>[]];
-  partition<RT, RF>(
+  partition<RT, RF, T2 extends T = T>(
     pred: (value: T, index: number) => boolean,
     options: {
-      collectorTrue: Reducer<T, RT>;
-      collectorFalse: Reducer<T, RF>;
+      collectorTrue: Reducer<T | T2, RT>;
+      collectorFalse: Reducer<T | T2, RF>;
     }
   ): [true: RT, false: RF];
   partition(
@@ -993,10 +1009,10 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => Map {0 => [2], 1 => [1, 3]}
    * ```
    */
-  groupBy<K, R>(
+  groupBy<K, R, T2 extends readonly [K, T] = [K, T]>(
     valueToKey: (value: T, index: number) => K,
     options: {
-      collector: Reducer<[K, T], R>;
+      collector: Reducer<[K, T] | T2, R>;
     }
   ): R;
   groupBy<K>(
@@ -1069,7 +1085,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => 8
    * ```
    */
-  reduce<R>(reducer: Reducer<T, R>): R;
+  reduce<R, T2 = T>(reducer: Reducer<T | T2, R>): R;
   /**
    * Applies the given combined `Reducer` to each element in the Stream, and returns the final result.
    * @typeparam S - a shape defining a combined reducer definition
@@ -1103,7 +1119,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [1, 2, 8]
    * ```
    */
-  reduceStream<R>(reducer: Reducer<T, R>): Stream<R>;
+  reduceStream<R, T2 = T>(reducer: Reducer<T | T2, R>): Stream<R>;
   /**
    * Returns a Stream where the given shape containing `Reducers` is applied to each element in the stream.
    * @typeparam S - the reducer shape type
@@ -1291,8 +1307,12 @@ export namespace Stream {
      * // => [[1, 2, 3], [4, 5, 6]]
      * ```
      */
-    transform<R>(transformer: Transformer.NonEmpty<T, R>): Stream.NonEmpty<R>;
-    transform<R>(transformer: Transformer<T, R>): Stream<R>;
+    transform<R, T2 extends T = T>(
+      transformer: Transformer.NonEmpty<T | T2, R>
+    ): Stream.NonEmpty<R>;
+    transform<R, T2 extends T = T>(
+      transformer: Transformer<T | T2, R>
+    ): Stream<R>;
     /**
      * Returns the first element of the Stream.
      * @example

--- a/deno_dist/stream/main/transformer.ts
+++ b/deno_dist/stream/main/transformer.ts
@@ -190,10 +190,10 @@ export namespace Transformer {
   } = <T, TF>(
     pred: (value: T, index: number, halt: () => void) => boolean,
     options: { negate?: boolean | undefined } = {}
-  ): Transformer<never> => {
+  ): any => {
     const { negate = false } = options;
 
-    return flatMap((value, index, halt) =>
+    return flatMap<T, T>((value, index, halt) =>
       pred(value, index, halt) !== negate ? Stream.of(value) : Stream.empty()
     );
   };

--- a/deno_dist/table/CHANGELOG.md
+++ b/deno_dist/table/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/table@2.0.0...@rimbu/table@2.0.1) (2024-02-14)
+
+**Note:** Version bump only for package @rimbu/table
+
 # [2.0.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/table@1.1.3...@rimbu/table@2.0.0) (2024-01-26)
 
 ### Features

--- a/deno_dist/table/custom/implementation/base.ts
+++ b/deno_dist/table/custom/implementation/base.ts
@@ -968,7 +968,7 @@ export class TableContext<
 
   readonly reducer = <R extends UR, C extends UC, V>(
     source?: StreamSource<readonly [R, C, V]>
-  ): Reducer<[R, C, V], WithRow<Tp, R, C, V>['normal']> => {
+  ): Reducer<readonly [R, C, V], WithRow<Tp, R, C, V>['normal']> => {
     return Reducer.create(
       () =>
         undefined === source

--- a/deno_dist/table/custom/interface/base.ts
+++ b/deno_dist/table/custom/interface/base.ts
@@ -726,7 +726,7 @@ export namespace TableBase {
      */
     reducer<R extends UR, C extends UC, V>(
       source?: StreamSource<readonly [R, C, V]>
-    ): Reducer<[R, C, V], WithRow<Tp, R, C, V>['normal']>;
+    ): Reducer<readonly [R, C, V], WithRow<Tp, R, C, V>['normal']>;
   }
 
   export interface Context<UR, UC, Tp extends TableBase.Types = TableBase.Types>

--- a/packages/bimultimap/src/custom/implementation/context.mts
+++ b/packages/bimultimap/src/custom/implementation/context.mts
@@ -109,7 +109,7 @@ export class BiMultiMapContext<
 
   readonly reducer = <K extends UK, V extends UV>(
     source?: StreamSource<readonly [K, V]>
-  ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']> => {
+  ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']> => {
     return Reducer.create(
       () =>
         undefined === source

--- a/packages/bimultimap/src/custom/interface/base.mts
+++ b/packages/bimultimap/src/custom/interface/base.mts
@@ -561,7 +561,7 @@ export namespace BiMultiMapBase {
      */
     reducer<K extends UK, V extends UV>(
       source?: StreamSource<readonly [K, V]>
-    ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']>;
+    ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']>;
   }
 
   export interface Context<

--- a/packages/multimap/src/custom/implementation/base.mts
+++ b/packages/multimap/src/custom/implementation/base.mts
@@ -721,7 +721,7 @@ export class MultiMapContext<
 
   readonly reducer = <K extends UK, V extends UV>(
     source?: StreamSource<readonly [K, V]>
-  ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']> => {
+  ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']> => {
     return Reducer.create(
       () =>
         undefined === source

--- a/packages/multimap/src/custom/interface/base.mts
+++ b/packages/multimap/src/custom/interface/base.mts
@@ -590,7 +590,7 @@ export namespace MultiMapBase {
      */
     reducer<K extends UK, V extends UV>(
       source?: StreamSource<readonly [K, V]>
-    ): Reducer<[K, V], WithKeyValue<Tp, K, V>['normal']>;
+    ): Reducer<readonly [K, V], WithKeyValue<Tp, K, V>['normal']>;
   }
 
   /**

--- a/packages/stream/src/async-custom/async-stream-custom.mts
+++ b/packages/stream/src/async-custom/async-stream-custom.mts
@@ -181,6 +181,26 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
     return new AsyncFilterPureStream<T, A>(this, pred, args, negate);
   }
 
+  withOnly<F extends T>(values: F[]): AsyncStream<F> {
+    if (values.length <= 0) {
+      return this as any;
+    }
+
+    const set = new Set<T>(values);
+
+    return this.filterPure({ pred: (v) => set.has(v) });
+  }
+
+  without<F extends T>(values: F[]): any {
+    if (values.length <= 0) {
+      return this as any;
+    }
+
+    const set = new Set<T>(values);
+
+    return this.filterPure({ pred: (v) => set.has(v), negate: true });
+  }
+
   map<T2>(
     mapFun: (value: T, index: number) => MaybePromise<T2>
   ): AsyncStream<T2> {
@@ -757,7 +777,9 @@ export abstract class AsyncStreamBase<T> implements AsyncStream<T> {
 
   groupBy<K, R>(
     valueToKey: (value: T, index: number) => MaybePromise<K>,
-    options: { collector?: AsyncReducer.Accept<[K, T], R> | undefined } = {}
+    options: {
+      collector?: AsyncReducer.Accept<readonly [K, T], R> | undefined;
+    } = {}
   ): Promise<R> {
     return (this as AsyncStream<T>).reduce(
       AsyncReducer.groupBy<T, K, R>(valueToKey, options as any)

--- a/packages/stream/src/async/async-reducer.mts
+++ b/packages/stream/src/async/async-reducer.mts
@@ -255,9 +255,9 @@ export namespace AsyncReducer {
      * // this reducer will double all input values before summing them
      * ```
      */
-    mapInput<I2>(
+    mapInput: <I2>(
       mapFun: (value: I2, index: number) => MaybePromise<I>
-    ): AsyncReducer<I2, O>;
+    ) => AsyncReducer<I2, O>;
     /**
      * Returns an `AsyncReducer` instance that converts its input values using given `flatMapFun` before passing them to the reducer.
      * @param flatMapFun - a potentially asynchronous function that returns am arbitrary number of new values to pass to the reducer based on the following inputs:<br/>
@@ -383,53 +383,6 @@ export namespace AsyncReducer {
       options?: { negate?: boolean | undefined }
     ): AsyncReducer<I, O>;
     /**
-     * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
-     * by the previous reducer.
-     * @typeparam O1 - the output type of the `nextReducer1` reducer
-     * @typeparam O2 - the output type of the `nextReducer2` reducer
-     * @typeparam O3 - the output type of the `nextReducer3` reducer
-     * @typeparam O4 - the output type of the `nextReducer4` reducer
-     * @typeparam O5 - the output type of the `nextReducer5` reducer
-     * @param nextReducer1 - the next reducer to apply to each output of this reducer.
-     * @param nextReducer2 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer3 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer4 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer5 - (optional) the next reducer to apply to each output of this reducer.
-     * @example
-     * ```ts
-     * AsyncStream
-     *  .from(Stream.of(1, 2, 3))
-     *  .reduce(
-     *    AsyncReducer.product
-     *      .pipe(AsyncReducer.sum)
-     *  )
-     * // => 9
-     * ```
-     */
-    pipe<O1>(nextReducer1: AsyncReducer.Accept<O, O1>): AsyncReducer<I, O1>;
-    pipe<O1, O2>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>
-    ): AsyncReducer<I, O2>;
-    pipe<O1, O2, O3>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>,
-      nextReducer3: AsyncReducer.Accept<O2, O3>
-    ): AsyncReducer<I, O3>;
-    pipe<O1, O2, O3, O4>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>,
-      nextReducer3: AsyncReducer.Accept<O2, O3>,
-      nextReducer4: AsyncReducer.Accept<O3, O4>
-    ): AsyncReducer<I, O4>;
-    pipe<O1, O2, O3, O4, O5>(
-      nextReducer1: AsyncReducer.Accept<O, O1>,
-      nextReducer2: AsyncReducer.Accept<O1, O2>,
-      nextReducer3: AsyncReducer.Accept<O2, O3>,
-      nextReducer4: AsyncReducer.Accept<O3, O4>,
-      nextReducer5: AsyncReducer.Accept<O4, O5>
-    ): AsyncReducer<I, O5>;
-    /**
      * Returns a reducer that applies the given `nextReducers` sequentially after this reducer
      * has halted, and moving on to the next provided reducer until it is halted. Optionally, it provides the last output
      * value of the previous reducer.
@@ -438,52 +391,21 @@ export namespace AsyncReducer {
      * ```ts
      * const result = await AsyncStream.range({ amount: 6 })
      *  .reduce(
-     *    AsyncReducer.sum
+     *    Reducer.sum
      *      .takeInput(3)
      *      .chain(
-     *        v => v > 10 ? AsyncReducer.product : AsyncReducer.sum
+     *        v => v > 10 ? Reducer.product : Reducer.sum
      *      )
      *    )
      * console.log(result)
      * // => 21
      * ```
      */
-    chain<O1>(
-      nextReducers: [AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>]
-    ): AsyncReducer<I, O1>;
-    chain<O1, O2>(
-      nextReducer: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>
-      ]
+    chain<O2 extends O>(
+      nextReducers: AsyncStreamSource<
+        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O2]>
+      >
     ): AsyncReducer<I, O2>;
-    chain<O1, O2, O3>(
-      nextReducers: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>
-      ]
-    ): AsyncReducer<I, O3>;
-    chain<O1, O2, O3, O4>(
-      nextReducers: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>
-      ]
-    ): AsyncReducer<I, O4>;
-    chain<O1, O2, O3, O4, O5>(
-      nextReducers: [
-        AsyncOptLazy<AsyncReducer.Accept<I, O1>, [O]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O1]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O3>, [O2]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O4>, [O3]>,
-        AsyncOptLazy<AsyncReducer.Accept<I, O5>, [O4]>
-      ]
-    ): AsyncReducer<I, O5>;
-    chain(
-      nextReducers: AsyncStreamSource<AsyncOptLazy<AsyncReducer<I, any>, [any]>>
-    ): AsyncReducer<I, unknown>;
 
     /**
      * Returns a promise that resolves to a 'runnable' instance of the current reducer specification. This instance maintains its own state
@@ -491,7 +413,7 @@ export namespace AsyncReducer {
      * retrieved when needed. The state is kept private.
      * @example
      * ```ts
-     * const reducer = AsyncReducer.sum.mapOutput(v => v * 2);
+     * const reducer = AsyncReducer.from(Reducer.sum.mapOutput(v => v * 2));
      * const instance = reducer.compile();
      * await instance.next(3);
      * await instance.next(5);
@@ -713,108 +635,72 @@ export namespace AsyncReducer {
       return this.takeInput(amount).dropInput(from);
     }
 
-    pipe<O2>(
-      ...nextReducers: AsyncReducer.Accept<O, O2>[]
+    chain<O2 extends O>(
+      nextReducers: AsyncStreamSource<
+        AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O2]>
+      >
     ): AsyncReducer<I, O2> {
-      if (nextReducers.length <= 0) {
-        return this as any;
-      }
-
-      const [nextReducer, ...others] = nextReducers as AsyncReducer.Accept<
-        any,
-        any
-      >[];
-
-      if (others.length > 0) {
-        return (this.pipe(nextReducer).pipe as any)(...others);
-      }
-
       return AsyncReducer.create(
-        async (inithalt) => {
-          const thisInstance = await this.compile();
-          const nextInstance = await AsyncReducer.from(nextReducer).compile();
+        async (
+          initHalt
+        ): Promise<{
+          activeInstance: AsyncReducer.Instance<I, O2>;
+          iterator: AsyncFastIterator<
+            AsyncOptLazy<AsyncReducer.Accept<I, O2>, [O2]>
+          >;
+        }> => {
+          const iterator =
+            fromAsyncStreamSource(nextReducers)[Symbol.asyncIterator]();
+          let activeInstance = (await this.compile()) as AsyncReducer.Instance<
+            I,
+            O2
+          >;
 
-          if (thisInstance.halted || nextInstance.halted) {
-            inithalt();
+          if (undefined !== activeInstance && activeInstance.halted) {
+            let output = await activeInstance.getOutput();
+
+            do {
+              const creator = await iterator.fastNext();
+
+              if (undefined === creator) {
+                initHalt();
+
+                return {
+                  activeInstance,
+                  iterator,
+                };
+              }
+              const nextReducer = await AsyncOptLazy.toMaybePromise(
+                creator,
+                output
+              );
+
+              activeInstance = await AsyncReducer.from(nextReducer).compile();
+              output = await activeInstance.getOutput();
+            } while (activeInstance.halted);
           }
 
           return {
-            thisInstance,
-            nextInstance,
+            activeInstance,
+            iterator,
           };
         },
         async (state, next, index, halt) => {
-          const { thisInstance, nextInstance } = state;
-
-          await thisInstance.next(next);
-          await nextInstance.next(await thisInstance.getOutput());
-
-          if (thisInstance.halted || nextInstance.halted) {
-            halt();
-          }
-
-          return state;
-        },
-        async (state, index, halted) => {
-          if (halted && index === 0) {
-            await state.nextInstance.next(await state.thisInstance.getOutput());
-          }
-
-          return state.nextInstance.getOutput();
-        },
-        async (state, err) => {
-          await Promise.all([
-            state.thisInstance.onClose(err),
-            state.nextInstance.onClose(err),
-          ]);
-        }
-      );
-    }
-
-    chain(
-      nextReducers: AsyncStreamSource<
-        AsyncOptLazy<AsyncReducer.Accept<I, any>, [any]>
-      >
-    ): AsyncReducer<I, O> {
-      return AsyncReducer.create(
-        async () => ({
-          activeInstance: (await this.compile()) as AsyncReducer.Instance<I, O>,
-          iterator: fromAsyncStreamSource(nextReducers)[Symbol.asyncIterator](),
-        }),
-        async (state, next, index, halt) => {
-          const done = Symbol();
-
-          while (state.activeInstance.halted) {
-            const nextItem = await state.iterator.fastNext(done);
-
-            if (done === nextItem) {
-              halt();
-              return state;
-            }
-
-            const nextReducer = await AsyncOptLazy.toMaybePromise(
-              nextItem,
-              await state.activeInstance.getOutput()
-            );
-
-            state.activeInstance = await AsyncReducer.from(
-              nextReducer
-            ).compile();
-          }
-
           await state.activeInstance.next(next);
 
           while (state.activeInstance.halted) {
-            const nextItem = await state.iterator.fastNext(done);
+            const output = await state.activeInstance.getOutput();
+            const creator = await state.iterator.fastNext();
 
-            if (done === nextItem) {
+            if (undefined === creator) {
               halt();
+
               return state;
             }
 
             const nextReducer = await AsyncOptLazy.toMaybePromise(
-              nextItem,
-              await state.activeInstance.getOutput()
+              creator,
+              output
             );
 
             state.activeInstance = await AsyncReducer.from(
@@ -824,8 +710,7 @@ export namespace AsyncReducer {
 
           return state;
         },
-        (state) => state.activeInstance.getOutput(),
-        (state, err) => state.activeInstance.onClose(err)
+        (state) => state.activeInstance.getOutput()
       );
     }
 
@@ -1546,7 +1431,8 @@ export namespace AsyncReducer {
   ): AsyncReducer<T, boolean> {
     const { eq, amount = 1 } = options;
 
-    return endsWithSlice(slice, { eq }).pipe(
+    return AsyncReducer.pipe(
+      endsWithSlice(slice, { eq }),
       Reducer.contains(true, { amount })
     );
   }
@@ -1639,10 +1525,10 @@ export namespace AsyncReducer {
    * ```
    */
   export const groupBy: {
-    <T, K, R>(
+    <T, K, R, T2 extends readonly [K, T] = [K, T]>(
       valueToKey: (value: T, index: number) => MaybePromise<K>,
       options: {
-        collector: AsyncReducer.Accept<[K, T], R>;
+        collector: AsyncReducer.Accept<[K, T] | T2, R>;
       }
     ): AsyncReducer<T, R>;
     <T, K>(
@@ -1654,11 +1540,14 @@ export namespace AsyncReducer {
   } = <T, K, R>(
     valueToKey: (value: T, index: number) => MaybePromise<K>,
     options: {
-      collector?: AsyncReducer.Accept<[K, T], R> | undefined;
+      collector?: AsyncReducer.Accept<readonly [K, T], R> | undefined;
     } = {}
   ): AsyncReducer<T, R> => {
     const {
-      collector = Reducer.toJSMultiMap() as AsyncReducer.Accept<[K, T], R>,
+      collector = Reducer.toJSMultiMap() as AsyncReducer.Accept<
+        readonly [K, T],
+        R
+      >,
     } = options;
 
     return AsyncReducer.create(
@@ -1740,8 +1629,8 @@ export namespace AsyncReducer {
    * Type defining the allowed shape of async reducer combinations.
    * @typeparam T - the input type
    */
-  export type CombineShape<T = unknown> =
-    | AsyncReducer.Accept<T, unknown>
+  export type CombineShape<T> =
+    | AsyncReducer.Accept<T, any>
     | AsyncReducer.CombineShape<T>[]
     | { [key: string]: AsyncReducer.CombineShape<T> };
 
@@ -1750,19 +1639,19 @@ export namespace AsyncReducer {
    * @typeparam S - the reducer combination shape
    */
   export type CombineResult<S extends AsyncReducer.CombineShape<any>> =
-    /* tuple */ S extends readonly AsyncReducer.CombineShape[]
+    /* tuple */ S extends readonly AsyncReducer.CombineShape<any>[]
       ? /* is array? */ 0 extends S['length']
         ? AsyncReducer.CombineResult<S[number]>[]
         : /* only tuples */ {
-            [K in keyof S]: S[K] extends AsyncReducer.CombineShape
+            [K in keyof S]: S[K] extends AsyncReducer.CombineShape<any>
               ? AsyncReducer.CombineResult<S[K]>
               : never;
           }
       : /* plain object */ S extends {
-          [key: string]: AsyncReducer.CombineShape;
+          [key: string]: AsyncReducer.CombineShape<any>;
         }
       ? { [K in keyof S]: AsyncReducer.CombineResult<S[K]> }
-      : /* simple reducer */ S extends AsyncReducer.Accept<unknown, infer R>
+      : /* simple reducer */ S extends AsyncReducer.Accept<any, infer R>
       ? R
       : never;
 
@@ -1824,4 +1713,114 @@ export namespace AsyncReducer {
 
     throw new AsyncReducer.InvalidCombineShapeError();
   }
+
+  /**
+   * Returns an `AsyncReducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
+   * by the previous reducer.
+   * @typeparam I - the input type of the `reducer1` reducer
+   * @typeparam O1 - the output type of the `reducer1` reducer
+   * @typeparam O2 - the output type of the `reducer2` reducer
+   * @typeparam O3 - the output type of the `reducer3` reducer
+   * @typeparam O4 - the output type of the `reducer4` reducer
+   * @typeparam O5 - the output type of the `reducer5` reducer
+   * @param reducer1 - the next reducer to apply to each output of this reducer.
+   * @param reducer2 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer3 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer4 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer5 - (optional) the next reducer to apply to each output of this reducer.
+   * @example
+   * ```ts
+   * AsyncStream
+   *  .from(Stream.of(1, 2, 3))
+   *  .reduce(
+   *    AsyncReducer.pipe(Reducer.product, Reducer.sum)
+   *  )
+   * // => 9
+   * ```
+   */
+  export const pipe: {
+    <I, O1, O2>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>
+    ): AsyncReducer<I, O2>;
+    <I, O1, O2, O3>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>,
+      reducer3: AsyncReducer.Accept<O2, O3>
+    ): AsyncReducer<I, O3>;
+    <I, O1, O2, O3, O4>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>,
+      reducer3: AsyncReducer.Accept<O2, O3>,
+      reducer4: AsyncReducer.Accept<O2, O4>
+    ): AsyncReducer<I, O4>;
+    <I, O1, O2, O3, O4, O5>(
+      reducer1: AsyncReducer.Accept<I, O1>,
+      reducer2: AsyncReducer.Accept<O1, O2>,
+      reducer3: AsyncReducer.Accept<O2, O3>,
+      reducer4: AsyncReducer.Accept<O2, O4>,
+      reducer5: AsyncReducer.Accept<O2, O5>
+    ): AsyncReducer<I, O5>;
+  } = (...nextReducers: AsyncReducer.Accept<any, any>[]): any => {
+    if (nextReducers.length < 2) {
+      RimbuError.throwInvalidUsageError(
+        'Reducer.pipe should have at least two arguments'
+      );
+    }
+
+    const [current, next, ...others] = nextReducers as AsyncReducer.Accept<
+      any,
+      any
+    >[];
+
+    if (others.length > 0) {
+      return AsyncReducer.pipe(
+        current,
+        (AsyncReducer.pipe as any)(next, ...others)
+      );
+    }
+
+    return AsyncReducer.create(
+      async (inithalt) => {
+        const currentInstance = await AsyncReducer.from(current).compile();
+        const nextInstance = await AsyncReducer.from(next).compile();
+
+        if (currentInstance.halted || nextInstance.halted) {
+          inithalt();
+        }
+
+        return {
+          currentInstance,
+          nextInstance,
+        };
+      },
+      async (state, next, index, halt) => {
+        const { currentInstance, nextInstance } = state;
+
+        await currentInstance.next(next);
+        await nextInstance.next(await currentInstance.getOutput());
+
+        if (currentInstance.halted || nextInstance.halted) {
+          halt();
+        }
+
+        return state;
+      },
+      async (state, index, halted) => {
+        if (halted && index === 0) {
+          await state.nextInstance.next(
+            await state.currentInstance.getOutput()
+          );
+        }
+
+        return state.nextInstance.getOutput();
+      },
+      async (state, err) => {
+        await Promise.all([
+          state.currentInstance.onClose(err),
+          state.nextInstance.onClose(err),
+        ]);
+      }
+    );
+  };
 }

--- a/packages/stream/src/async/async-stream.mts
+++ b/packages/stream/src/async/async-stream.mts
@@ -4,9 +4,9 @@ import type {
   AsyncStreamable,
   AsyncTransformer,
   AsyncReducer,
-} from '../../stream/mod.ts';
-import type { AsyncStreamConstructors } from '../../stream/async-custom/index.ts';
-import { AsyncStreamConstructorsImpl } from '../../stream/async-custom/index.ts';
+} from '@rimbu/stream';
+import type { AsyncStreamConstructors } from '@rimbu/stream/async-custom';
+import { AsyncStreamConstructorsImpl } from '@rimbu/stream/async-custom';
 
 import type {
   ArrayNonEmpty,
@@ -16,7 +16,7 @@ import type {
   MaybePromise,
   ToJSON,
   TraverseState,
-} from '../../common/mod.ts';
+} from '@rimbu/common';
 
 /**
  * A possibly infinite asynchronous sequence of elements of type T.
@@ -246,7 +246,9 @@ export interface AsyncStream<T>
    * // => [[1, 2, 3], [4, 5, 6]]
    * ```
    */
-  transform<R>(transformer: AsyncTransformer.Accept<T, R>): AsyncStream<R>;
+  transform<R, T2 extends T = T>(
+    transformer: AsyncTransformer.Accept<T | T2, R>
+  ): AsyncStream<R>;
   /**
    * Returns an AsyncStream containing only those elements from this stream for which the given `pred` function returns true.
    * @param pred - a potentially asynchronous function taking an element and its index, and returning true if the element should be included in the resulting stream.
@@ -312,6 +314,20 @@ export interface AsyncStream<T>
     },
     ...args: A
   ): AsyncStream<T>;
+  /**
+   * Returns an AsyncStream containing only those elements that are in the given `values` array.
+   * @typeparam F - a subtype of T to indicate the resulting element type
+   * @param values - an array of values to include
+   */
+  withOnly<F extends T>(values: F[]): AsyncStream<F>;
+  /**
+   * Returns an AsyncStream containing all elements except the elements in the given `values` array.
+   * @typeparam F - a subtype of T to indicate the resulting element type
+   * @param values - an array of values to exclude
+   */
+  without<F extends T>(
+    values: F[]
+  ): AsyncStream<T extends Exclude<T, F> ? T : Exclude<T, F>>;
   /**
    * Returns an AsyncStream containing the resulting elements from applying the given `collectFun` to each element in this Stream.
    * @typeparam R - the resulting element type
@@ -863,11 +879,11 @@ export interface AsyncStream<T>
    * ```
    * @note O(1)
    */
-  splitWhere<R>(
+  splitWhere<R, T2 extends T = T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: {
       negate?: boolean | undefined;
-      collector: AsyncReducer.Accept<T, R>;
+      collector: AsyncReducer.Accept<T | T2, R>;
     }
   ): AsyncStream<R>;
   splitWhere(
@@ -890,11 +906,11 @@ export interface AsyncStream<T>
    * @note O(1)
    */
   splitOn<R, T2 extends T = T>(
-    sepElem: T2,
+    sepElem: T,
     options?: {
-      eq?: Eq<T2> | undefined;
+      eq?: Eq<T> | undefined;
       negate?: boolean | undefined;
-      collector: AsyncReducer.Accept<T, R>;
+      collector: AsyncReducer.Accept<T | T2, R>;
     }
   ): AsyncStream<R>;
   splitOn(
@@ -920,14 +936,14 @@ export interface AsyncStream<T>
    * @note O(1)
    */
   splitOnSlice<R, T2 extends T = T>(
-    sepSlice: AsyncStreamSource<T & T2>,
+    sepSlice: AsyncStreamSource<T>,
     options: {
       eq?: Eq<T> | undefined;
-      collector: AsyncReducer.Accept<T & T2, R>;
+      collector: AsyncReducer.Accept<T | T2, R>;
     }
   ): AsyncStream<R>;
-  splitOnSlice<T2 extends T = T>(
-    sepSlice: AsyncStreamSource<T & T2>,
+  splitOnSlice(
+    sepSlice: AsyncStreamSource<T>,
     options?: { eq?: Eq<T> | undefined; collector?: undefined }
   ): AsyncStream<T[]>;
   /**
@@ -964,11 +980,11 @@ export interface AsyncStream<T>
    * // => [Set(1, 2), Set(3, 4)]
    * ```
    */
-  window<R>(
+  window<R, T2 extends T = T>(
     windowSize: number,
     options: {
       skipAmount?: number | undefined;
-      collector: AsyncReducer.Accept<T, R>;
+      collector: AsyncReducer.Accept<T | T2, R>;
     }
   ): AsyncStream<R>;
   window(
@@ -1002,11 +1018,11 @@ export interface AsyncStream<T>
       collectorFalse?: undefined;
     }
   ): Promise<[true: T2[], false: Exclude<T, T2>[]]>;
-  partition<RT, RF = RT>(
+  partition<RT, RF = RT, T2 extends T = T>(
     pred: (value: T, index: number) => MaybePromise<boolean>,
     options: {
-      collectorTrue: AsyncReducer.Accept<T, RT>;
-      collectorFalse: AsyncReducer.Accept<T, RF>;
+      collectorTrue: AsyncReducer.Accept<T | T2, RT>;
+      collectorFalse: AsyncReducer.Accept<T | T2, RF>;
     }
   ): Promise<[true: RT, false: RF]>;
   partition(
@@ -1032,10 +1048,10 @@ export interface AsyncStream<T>
    * // => Map {0 => [2], 1 => [1, 3]}
    * ```
    */
-  groupBy<K, R>(
+  groupBy<K, R, T2 extends readonly [K, T] = [K, T]>(
     valueToKey: (value: T, index: number) => MaybePromise<K>,
     options: {
-      collector: AsyncReducer.Accept<[K, T], R>;
+      collector: AsyncReducer.Accept<[K, T] | T2, R>;
     }
   ): Promise<R>;
   groupBy<K>(
@@ -1119,7 +1135,9 @@ export interface AsyncStream<T>
    * // => 8
    * ```
    */
-  reduce<R>(reducer: AsyncReducer.Accept<T, R>): Promise<R>;
+  reduce<R, T2 extends T = T>(
+    reducer: AsyncReducer.Accept<T | T2, R>
+  ): Promise<R>;
   /**
    * Applies the given combined `(Async)Reducer` to each element in the AsyncStream, and returns the final result.
    * @typeparam S - a shape defining a combined reducer definition
@@ -1153,7 +1171,9 @@ export interface AsyncStream<T>
    * // => [1, 2, 8]
    * ```
    */
-  reduceStream<R>(reducer: AsyncReducer.Accept<T, R>): AsyncStream<R>;
+  reduceStream<R, T2 extends T = T>(
+    reducer: AsyncReducer.Accept<T | T2, R>
+  ): AsyncStream<R>;
   /**
    * Returns an AsyncStream where the given shape containing `AsyncReducers` is applied to each element in the stream.
    * @typeparam S - the reducer shape type
@@ -1345,10 +1365,12 @@ export namespace AsyncStream {
      * // => [[1, 2, 3], [4, 5, 6]]
      * ```
      */
-    transform<R>(
-      transformer: AsyncTransformer.AcceptNonEmpty<T, R>
+    transform<R, T2 extends T = T>(
+      transformer: AsyncTransformer.AcceptNonEmpty<T | T2, R>
     ): AsyncStream.NonEmpty<R>;
-    transform<R>(transformer: AsyncTransformer.Accept<T, R>): AsyncStream<R>;
+    transform<R, T2 extends T = T>(
+      transformer: AsyncTransformer.Accept<T | T2, R>
+    ): AsyncStream<R>;
     /**
      * Returns the first element of the AsyncStream.
      * @example

--- a/packages/stream/src/async/async-transformer.mts
+++ b/packages/stream/src/async/async-transformer.mts
@@ -93,7 +93,7 @@ export namespace AsyncTransformer {
       skipAmount?: number | undefined;
       collector?: AsyncReducer.Accept<T, R> | undefined;
     } = {}
-  ) => {
+  ): AsyncTransformer<T, R> => {
     const {
       skipAmount = windowSize,
       collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
@@ -101,7 +101,7 @@ export namespace AsyncTransformer {
 
     return AsyncReducer.create<
       T,
-      AsyncStream<R>,
+      AsyncStreamSource<R>,
       Set<AsyncReducer.Instance<T, R>>
     >(
       () => new Set(),
@@ -301,7 +301,11 @@ export namespace AsyncTransformer {
       collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
     } = options;
 
-    return AsyncReducer.create(
+    return AsyncReducer.create<
+      T,
+      AsyncStreamSource<R>,
+      { collection: AsyncReducer.Instance<T, R>; done: boolean }
+    >(
       async () => ({
         collection: await AsyncReducer.from(collector).compile(),
         done: false,
@@ -352,7 +356,11 @@ export namespace AsyncTransformer {
       collector = Reducer.toArray() as AsyncReducer.Accept<T, R>,
     } = options;
 
-    return AsyncReducer.create(
+    return AsyncReducer.create<
+      T,
+      AsyncStreamSource<R>,
+      { collection: AsyncReducer.Instance<T, R>; done: boolean }
+    >(
       async () => ({
         collection: await AsyncReducer.from(collector).compile(),
         done: false,
@@ -402,7 +410,7 @@ export namespace AsyncTransformer {
 
     return AsyncReducer.create<
       T,
-      AsyncStream<R>,
+      AsyncStreamSource<R>,
       {
         done: boolean;
         instances: Map<AsyncReducer.Instance<T, boolean>, number>;

--- a/packages/stream/src/async/index.mts
+++ b/packages/stream/src/async/index.mts
@@ -11,7 +11,7 @@ export * from './async-fast-iterator.mjs';
 export * from './async-fast-iterable.mjs';
 export * from './async-streamable.mjs';
 
-export * from './interface.mjs';
+export * from './async-stream.mjs';
 
 export * from './async-reducer.mjs';
 export * from './async-transformer.mjs';

--- a/packages/stream/src/main/index.mts
+++ b/packages/stream/src/main/index.mts
@@ -14,7 +14,7 @@ export * from './fast-iterable.mjs';
 export * from './streamable.mjs';
 export * from './stream-source.mjs';
 
-export * from './interface.mjs';
+export * from './stream.mjs';
 
 export * from './reducer.mjs';
 export * from './transformer.mjs';

--- a/packages/stream/src/main/reducer.mts
+++ b/packages/stream/src/main/reducer.mts
@@ -194,7 +194,7 @@ export namespace Reducer {
      * // this reducer will double all input values before summing them
      * ```
      */
-    mapInput<I2>(mapFun: (value: I2, index: number) => I): Reducer<I2, O>;
+    mapInput: <I2>(mapFun: (value: I2, index: number) => I) => Reducer<I2, O>;
     /**
      * Returns a `Reducer` instance that converts each output value from some source reducer into an arbitrary number of output values
      * using given `flatMapFun` before passing them to this reducer.
@@ -292,55 +292,8 @@ export namespace Reducer {
       options?: { negate?: boolean }
     ): Reducer<I, O>;
     /**
-     * Returns a `Reducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
-     * by the previous reducer.
-     * @typeparam O1 - the output type of the `nextReducer1` reducer
-     * @typeparam O2 - the output type of the `nextReducer2` reducer
-     * @typeparam O3 - the output type of the `nextReducer3` reducer
-     * @typeparam O4 - the output type of the `nextReducer4` reducer
-     * @typeparam O5 - the output type of the `nextReducer5` reducer
-     * @param nextReducer1 - the next reducer to apply to each output of this reducer.
-     * @param nextReducer2 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer3 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer4 - (optional) the next reducer to apply to each output of this reducer.
-     * @param nextReducer5 - (optional) the next reducer to apply to each output of this reducer.
-     * @example
-     * ```ts
-     * Stream.of(1, 2, 3)
-     *  .reduce(
-     *    Reducer.product
-     *      .pipe(Reducer.sum)
-     *    )
-     * // => 9
-     * ```
-     */
-    pipe<O1>(nextReducer1: Reducer<O, O1>): Reducer<I, O1>;
-    pipe<O1, O2>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>
-    ): Reducer<I, O2>;
-    pipe<O1, O2, O3>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>,
-      nextReducer3: Reducer<O2, O3>
-    ): Reducer<I, O3>;
-    pipe<O1, O2, O3, O4>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>,
-      nextReducer3: Reducer<O2, O3>,
-      nextReducer4: Reducer<O3, O4>
-    ): Reducer<I, O4>;
-    pipe<O1, O2, O3, O4, O5>(
-      nextReducer1: Reducer<O, O1>,
-      nextReducer2: Reducer<O1, O2>,
-      nextReducer3: Reducer<O2, O3>,
-      nextReducer4: Reducer<O3, O4>,
-      nextReducer5: Reducer<O4, O5>
-    ): Reducer<I, O5>;
-    /**
-     * Returns a reducer that applies the given `nextReducers` sequentially after this reducer
-     * has halted, and moving on to the next provided reducer until it is halted. Optionally, it provides the last output
-     * value of the previous reducer.
+     * Returns a reducer that applies this reducer and then the `nextReducers` sequentially on halting of each reducer.
+     * It provides the last output value of the active reducer.
      * @param nextReducers - an number of reducers consuming and producing the same types as the current reducer.
      * @example
      * ```ts
@@ -356,40 +309,9 @@ export namespace Reducer {
      * // => 21
      * ```
      */
-    chain<O1>(nextReducers: [OptLazy<Reducer<I, O1>, [O]>]): Reducer<I, O1>;
-    chain<O1, O2>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>
-      ]
+    chain<O2 extends O>(
+      nextReducers: StreamSource<OptLazy<Reducer<I, O2>, [O2]>>
     ): Reducer<I, O2>;
-    chain<O1, O2, O3>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>,
-        OptLazy<Reducer<I, O3>, [O2]>
-      ]
-    ): Reducer<I, O3>;
-    chain<O1, O2, O3, O4>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>,
-        OptLazy<Reducer<I, O3>, [O2]>,
-        OptLazy<Reducer<I, O4>, [O3]>
-      ]
-    ): Reducer<I, O4>;
-    chain<O1, O2, O3, O4, O5>(
-      nextReducers: [
-        OptLazy<Reducer<I, O1>, [O]>,
-        OptLazy<Reducer<I, O2>, [O1]>,
-        OptLazy<Reducer<I, O3>, [O2]>,
-        OptLazy<Reducer<I, O4>, [O3]>,
-        OptLazy<Reducer<I, O5>, [O4]>
-      ]
-    ): Reducer<I, O5>;
-    chain(
-      nextReducers: StreamSource<OptLazy<Reducer<I, any>, [any]>>
-    ): Reducer<I, unknown>;
     /**
      * Returns a 'runnable' instance of the current reducer specification. This instance maintains its own state
      * and indices, so that the instance only needs to be provided the input values, and output values can be
@@ -423,10 +345,10 @@ export namespace Reducer {
     filterInput(
       pred: (value: I, index: number, halt: () => void) => boolean,
       options: { negate?: boolean | undefined } = {}
-    ): Reducer<never, O> {
+    ): any {
       const { negate = false } = options;
 
-      return create(
+      return create<I, O, Reducer.Instance<I, O>>(
         () => this.compile(),
         (state, elem, index, halt) => {
           if (pred(elem, index, halt) !== negate) {
@@ -591,96 +513,57 @@ export namespace Reducer {
       return this.takeInput(amount).dropInput(from);
     }
 
-    pipe<O2>(...nextReducers: Reducer<O, O2>[]): Reducer<I, O2> {
-      if (nextReducers.length <= 0) {
-        return this as any;
-      }
-
-      const [nextReducer, ...others] = nextReducers as Reducer<any, any>[];
-
-      if (others.length > 0) {
-        return (this.pipe(nextReducer).pipe as any)(...others);
-      }
-
+    chain<O2 extends O>(
+      nextReducers: StreamSource<OptLazy<Reducer<I, O2>, [O2]>>
+    ): Reducer<I, O2> {
       return Reducer.create(
-        (initHalt) => {
-          const thisInstance = this.compile();
-          const nextInstance = nextReducer.compile();
+        (
+          initHalt
+        ): {
+          activeInstance: Reducer.Instance<I, O2>;
+          iterator: FastIterator<OptLazy<Reducer<I, O2>, [O2]>>;
+        } => {
+          const iterator = Stream.from(nextReducers)[Symbol.iterator]();
+          let activeInstance = this.compile() as Reducer.Instance<I, O2>;
 
-          if (thisInstance.halted || nextInstance.halted) {
-            initHalt();
+          if (undefined !== activeInstance && activeInstance.halted) {
+            let output = activeInstance.getOutput();
+
+            do {
+              const creator = iterator.fastNext();
+
+              if (undefined === creator) {
+                initHalt();
+
+                return {
+                  activeInstance,
+                  iterator,
+                };
+              }
+              activeInstance = OptLazy(creator, output).compile();
+              output = activeInstance.getOutput();
+            } while (activeInstance.halted);
           }
 
           return {
-            thisInstance,
-            nextInstance,
+            activeInstance,
+            iterator,
           };
         },
         (state, next, index, halt) => {
-          const { thisInstance, nextInstance } = state;
-
-          thisInstance.next(next);
-          nextInstance.next(thisInstance.getOutput());
-
-          if (thisInstance.halted || nextInstance.halted) {
-            halt();
-          }
-
-          return state;
-        },
-        (state, index, halted) => {
-          if (halted && index === 0) {
-            state.nextInstance.next(state.thisInstance.getOutput());
-          }
-
-          return state.nextInstance.getOutput();
-        }
-      );
-    }
-
-    chain(
-      nextReducers: StreamSource<OptLazy<Reducer<I, any>, [any]>>
-    ): Reducer<I, O> {
-      return Reducer.create(
-        () => ({
-          activeInstance: this.compile() as Reducer.Instance<I, O>,
-          iterator: Stream.from(nextReducers)[Symbol.iterator](),
-        }),
-        (state, next, index, halt) => {
-          const done = Symbol();
-
-          while (state.activeInstance.halted) {
-            const nextItem = state.iterator.fastNext(done);
-
-            if (done === nextItem) {
-              halt();
-              return state;
-            }
-
-            const nextReducer = OptLazy(
-              nextItem,
-              state.activeInstance.getOutput()
-            );
-
-            state.activeInstance = nextReducer.compile();
-          }
-
           state.activeInstance.next(next);
 
           while (state.activeInstance.halted) {
-            const nextItem = state.iterator.fastNext(done);
+            const output = state.activeInstance.getOutput();
+            const creator = state.iterator.fastNext();
 
-            if (done === nextItem) {
+            if (undefined === creator) {
               halt();
+
               return state;
             }
 
-            const nextReducer = OptLazy(
-              nextItem,
-              state.activeInstance.getOutput()
-            );
-
-            state.activeInstance = nextReducer.compile();
+            state.activeInstance = OptLazy(creator, output).compile();
           }
 
           return state;
@@ -1271,11 +1154,11 @@ export namespace Reducer {
    * // => true
    * ```
    */
-  export function contains<T>(
-    elem: T,
+  export function contains<T, T2 extends T = T>(
+    elem: T2,
     options: {
       amount?: number;
-      eq?: Eq<T>;
+      eq?: Eq<T | T2>;
       negate?: boolean;
     } = {}
   ): Reducer<T, boolean> {
@@ -1439,7 +1322,8 @@ export namespace Reducer {
   ): Reducer<T, boolean> {
     const { eq, amount = 1 } = options;
 
-    return endsWithSlice(slice, { eq }).pipe(
+    return Reducer.pipe(
+      endsWithSlice(slice, { eq }),
       Reducer.contains(true, { amount })
     );
   }
@@ -1587,17 +1471,18 @@ export namespace Reducer {
     ): Reducer<T, [true: T[], false: T[]]>;
   } = <T, RT, RF = RT>(
     pred: (value: T, index: number) => boolean,
-    options: {
-      collectorTrue?: Reducer<T, RT> | undefined;
-      collectorFalse?: Reducer<T, RF> | undefined;
-    } = {}
-  ): Reducer<T, [true: RT, false: RF]> => {
-    const {
-      collectorTrue = Reducer.toArray() as Reducer<T, RT>,
-      collectorFalse = Reducer.toArray() as Reducer<T, RF>,
-    } = options;
+    options: any = {}
+  ): any => {
+    const collectorTrue: Reducer<T, RT> =
+      options.collectorTrue ?? Reducer.toArray();
+    const collectorFalse: Reducer<T, RF> =
+      options.collectorFalse ?? Reducer.toArray();
 
-    return Reducer.create(
+    return Reducer.create<
+      T,
+      [RT, RF],
+      [Reducer.Instance<T, RT>, Reducer.Instance<T, RF>]
+    >(
       () => [collectorTrue.compile(), collectorFalse.compile()],
       (state, value, index) => {
         const instanceIndex = pred(value, index) ? 0 : 1;
@@ -1627,10 +1512,10 @@ export namespace Reducer {
    * ```
    */
   export const groupBy: {
-    <T, K, R>(
+    <T, K, R, T2 extends readonly [K, T] = [K, T]>(
       valueToKey: (value: T, index: number) => K,
       options: {
-        collector: Reducer<[K, T], R>;
+        collector: Reducer<[K, T] | T2, R>;
       }
     ): Reducer<T, R>;
     <T, K>(
@@ -1642,11 +1527,12 @@ export namespace Reducer {
   } = <T, K, R>(
     valueToKey: (value: T, index: number) => K,
     options: {
-      collector?: Reducer<[K, T], R> | undefined;
+      collector?: Reducer<readonly [K, T], R> | undefined;
     } = {}
   ): Reducer<T, R> => {
-    const { collector = Reducer.toJSMultiMap() as Reducer<[K, T], R> } =
-      options;
+    const {
+      collector = Reducer.toJSMultiMap() as Reducer<readonly [K, T], R>,
+    } = options;
 
     return Reducer.create(
       () => collector.compile(),
@@ -1759,7 +1645,7 @@ export namespace Reducer {
    * // Map { 1 => 'a', 2 => 'b' }
    * ```
    */
-  export function toJSMap<K, V>(): Reducer<[K, V], Map<K, V>> {
+  export function toJSMap<K, V>(): Reducer<readonly [K, V], Map<K, V>> {
     return create(
       (): Map<K, V> => new Map(),
       (state, next): Map<K, V> => {
@@ -1781,7 +1667,7 @@ export namespace Reducer {
    * // Map { 1 => 'a', 2 => 'b' }
    * ```
    */
-  export function toJSMultiMap<K, V>(): Reducer<[K, V], Map<K, V[]>> {
+  export function toJSMultiMap<K, V>(): Reducer<readonly [K, V], Map<K, V[]>> {
     return create(
       (): Map<K, V[]> => new Map(),
       (state, [key, value]) => {
@@ -1847,27 +1733,29 @@ export namespace Reducer {
    * Type defining the allowed shape of reducer combinations.
    * @typeparam T - the input type
    */
-  export type CombineShape<T = unknown> =
-    | Reducer<T, unknown>
-    | CombineShape<T>[]
-    | { [key: string]: CombineShape<T> };
+  export type CombineShape<T> =
+    | Reducer<T, any>
+    | Reducer.CombineShape<T>[]
+    | { [key: string]: Reducer.CombineShape<T> };
 
   /**
    * Type defining the result type of a reducer combination for a given shape.
    * @typeparam S - the reducer combination shape
    */
-  export type CombineResult<S extends CombineShape> =
-    /* tuple */ S extends readonly CombineShape[]
+  export type CombineResult<S extends Reducer.CombineShape<any>> =
+    /* tuple */ S extends readonly Reducer.CombineShape<any>[]
       ? /* is array? */ 0 extends S['length']
-        ? CombineResult<S[number]>[]
+        ? Reducer.CombineResult<S[number]>[]
         : /* only tuples */ {
-            [K in keyof S]: S[K] extends CombineShape
-              ? CombineResult<S[K]>
+            [K in keyof S]: S[K] extends Reducer.CombineShape<any>
+              ? Reducer.CombineResult<S[K]>
               : never;
           }
-      : /* plain object */ S extends { [key: string]: CombineShape }
-      ? { [K in keyof S]: CombineResult<S[K]> }
-      : /* simple reducer */ S extends Reducer<unknown, infer R>
+      : /* plain object */ S extends {
+          [key: string]: Reducer.CombineShape<any>;
+        }
+      ? { [K in keyof S]: Reducer.CombineResult<S[K]> }
+      : /* simple reducer */ S extends Reducer<any, infer R>
       ? R
       : never;
 
@@ -1920,4 +1808,99 @@ export namespace Reducer {
 
     throw new Reducer.InvalidCombineShapeError();
   }
+
+  /**
+   * Returns a `Reducer` instance that first applies this reducer, and then applies the given `next` reducer to each output produced
+   * by the previous reducer.
+   * @typeparam I - the input type of the `reducer1` reducer
+   * @typeparam O1 - the output type of the `reducer1` reducer
+   * @typeparam O2 - the output type of the `reducer2` reducer
+   * @typeparam O3 - the output type of the `reducer3` reducer
+   * @typeparam O4 - the output type of the `reducer4` reducer
+   * @typeparam O5 - the output type of the `reducer5` reducer
+   * @param reducer1 - the next reducer to apply to each output of this reducer.
+   * @param reducer2 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer3 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer4 - (optional) the next reducer to apply to each output of this reducer.
+   * @param reducer5 - (optional) the next reducer to apply to each output of this reducer.
+   * @example
+   * ```ts
+   * Stream.of(1, 2, 3)
+   *  .reduce(
+   *    Reducer.pipe(Reducer.product, Reducer.sum)
+   *  )
+   * // => 9
+   * ```
+   */
+  export const pipe: {
+    <I, O1, O2>(reducer1: Reducer<I, O1>, reducer2: Reducer<O1, O2>): Reducer<
+      I,
+      O2
+    >;
+    <I, O1, O2, O3>(
+      reducer1: Reducer<I, O1>,
+      reducer2: Reducer<O1, O2>,
+      reducer3: Reducer<O2, O3>
+    ): Reducer<I, O3>;
+    <I, O1, O2, O3, O4>(
+      reducer1: Reducer<I, O1>,
+      reducer2: Reducer<O1, O2>,
+      reducer3: Reducer<O2, O3>,
+      reducer4: Reducer<O2, O4>
+    ): Reducer<I, O4>;
+    <I, O1, O2, O3, O4, O5>(
+      reducer1: Reducer<I, O1>,
+      reducer2: Reducer<O1, O2>,
+      reducer3: Reducer<O2, O3>,
+      reducer4: Reducer<O2, O4>,
+      reducer5: Reducer<O2, O5>
+    ): Reducer<I, O5>;
+  } = (...nextReducers: Reducer<any, any>[]): any => {
+    if (nextReducers.length < 2) {
+      RimbuError.throwInvalidUsageError(
+        'Reducer.pipe should have at least two arguments'
+      );
+    }
+
+    const [current, next, ...others] = nextReducers as Reducer<any, any>[];
+
+    if (others.length > 0) {
+      return Reducer.pipe(current, (Reducer.pipe as any)(next, ...others));
+    }
+
+    return Reducer.create(
+      (inithalt) => {
+        const currentInstance = current.compile();
+        const nextInstance = next.compile();
+
+        if (currentInstance.halted || nextInstance.halted) {
+          inithalt();
+        }
+
+        return {
+          currentInstance,
+          nextInstance,
+        };
+      },
+      (state, next, index, halt) => {
+        const { currentInstance, nextInstance } = state;
+
+        currentInstance.next(next);
+        nextInstance.next(currentInstance.getOutput());
+
+        if (currentInstance.halted || nextInstance.halted) {
+          halt();
+        }
+
+        return state;
+      },
+      (state, index, halted) => {
+        if (halted && index === 0) {
+          state.nextInstance.next(state.currentInstance.getOutput());
+        }
+
+        return state.nextInstance.getOutput();
+      }
+    );
+  };
 }

--- a/packages/stream/src/main/stream.mts
+++ b/packages/stream/src/main/stream.mts
@@ -234,7 +234,9 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [[1, 2, 3], [4, 5, 6]]
    * ```
    */
-  transform<R>(transformer: Transformer<T, R>): Stream<R>;
+  transform<R, T2 extends T = T>(
+    transformer: Transformer<T | T2, R>
+  ): Stream<R>;
   /**
    * Returns a Stream containing only those elements from this Stream for which the given `pred` function returns true.
    * @param pred - a function taking an element and its index, and returning true if the element should be included in the resulting Stream.
@@ -296,6 +298,20 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
     },
     ...args: A
   ): Stream<T>;
+  /**
+   * Returns a Stream containing only those elements that are in the given `values` array.
+   * @typeparam F - a subtype of T to indicate the resulting element type
+   * @param values - an array of values to include
+   */
+  withOnly<F extends T>(values: F[]): Stream<F>;
+  /**
+   * Returns a Stream containing all elements except the elements in the given `values` array.
+   * @typeparam F - a subtype of T to indicate the resulting element type
+   * @param values - an array of values to exclude
+   */
+  without<F extends T>(
+    values: F[]
+  ): Stream<T extends Exclude<T, F> ? T : Exclude<T, F>>;
   /**
    * Returns a Stream containing the resulting elements from applying the given `collectFun` to each element in this Stream.
    * @typeparam R - the result element type
@@ -830,9 +846,9 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * ```
    * @note O(1)
    */
-  splitWhere<R>(
+  splitWhere<R, T2 extends T = T>(
     pred: (value: T, index: number) => boolean,
-    options: { negate?: boolean | undefined; collector: Reducer<T, R> }
+    options: { negate?: boolean | undefined; collector: Reducer<T | T2, R> }
   ): Stream<R>;
   splitWhere(
     pred: (value: T, index: number) => boolean,
@@ -854,13 +870,13 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @note O(1)
    */
   splitOn<R, T2 extends T = T>(
-    sepElem: T2,
+    sepElem: T,
     options: {
-      eq?: Eq<T2> | undefined;
+      eq?: Eq<T> | undefined;
       negate?: boolean | undefined;
-      collector: Reducer<T, R>;
+      collector: Reducer<T | T2, R>;
     }
-  ): Stream<T[]>;
+  ): Stream<R>;
   splitOn(
     sepElem: T,
     options?: {
@@ -884,11 +900,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * @note O(1)
    */
   splitOnSlice<R, T2 extends T = T>(
-    sepSlice: StreamSource<T & T2>,
-    options: { eq?: Eq<T> | undefined; collector: Reducer<T & T2, R> }
+    sepSlice: StreamSource<T>,
+    options: { eq?: Eq<T> | undefined; collector: Reducer<T | T2, R> }
   ): Stream<R>;
-  splitOnSlice<T2 extends T = T>(
-    sepSlice: StreamSource<T & T2>,
+  splitOnSlice(
+    sepSlice: StreamSource<T>,
     options?: { eq?: Eq<T> | undefined; collector?: undefined }
   ): Stream<T[]>;
   /**
@@ -925,11 +941,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [Set(1, 2), Set(3, 4)]
    * ```
    */
-  window<R>(
+  window<R, T2 extends T = T>(
     windowSize: number,
     options: {
       skipAmount?: number | undefined;
-      collector: Reducer<T, R>;
+      collector: Reducer<T | T2, R>;
     }
   ): Stream<R>;
   window(
@@ -963,11 +979,11 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
       collectorFalse?: undefined;
     }
   ): [true: T2[], false: Exclude<T, T2>[]];
-  partition<RT, RF>(
+  partition<RT, RF, T2 extends T = T>(
     pred: (value: T, index: number) => boolean,
     options: {
-      collectorTrue: Reducer<T, RT>;
-      collectorFalse: Reducer<T, RF>;
+      collectorTrue: Reducer<T | T2, RT>;
+      collectorFalse: Reducer<T | T2, RF>;
     }
   ): [true: RT, false: RF];
   partition(
@@ -993,10 +1009,10 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => Map {0 => [2], 1 => [1, 3]}
    * ```
    */
-  groupBy<K, R>(
+  groupBy<K, R, T2 extends readonly [K, T] = [K, T]>(
     valueToKey: (value: T, index: number) => K,
     options: {
-      collector: Reducer<[K, T], R>;
+      collector: Reducer<[K, T] | T2, R>;
     }
   ): R;
   groupBy<K>(
@@ -1069,7 +1085,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => 8
    * ```
    */
-  reduce<R>(reducer: Reducer<T, R>): R;
+  reduce<R, T2 = T>(reducer: Reducer<T | T2, R>): R;
   /**
    * Applies the given combined `Reducer` to each element in the Stream, and returns the final result.
    * @typeparam S - a shape defining a combined reducer definition
@@ -1103,7 +1119,7 @@ export interface Stream<T> extends FastIterable<T>, Streamable<T> {
    * // => [1, 2, 8]
    * ```
    */
-  reduceStream<R>(reducer: Reducer<T, R>): Stream<R>;
+  reduceStream<R, T2 = T>(reducer: Reducer<T | T2, R>): Stream<R>;
   /**
    * Returns a Stream where the given shape containing `Reducers` is applied to each element in the stream.
    * @typeparam S - the reducer shape type
@@ -1291,8 +1307,12 @@ export namespace Stream {
      * // => [[1, 2, 3], [4, 5, 6]]
      * ```
      */
-    transform<R>(transformer: Transformer.NonEmpty<T, R>): Stream.NonEmpty<R>;
-    transform<R>(transformer: Transformer<T, R>): Stream<R>;
+    transform<R, T2 extends T = T>(
+      transformer: Transformer.NonEmpty<T | T2, R>
+    ): Stream.NonEmpty<R>;
+    transform<R, T2 extends T = T>(
+      transformer: Transformer<T | T2, R>
+    ): Stream<R>;
     /**
      * Returns the first element of the Stream.
      * @example

--- a/packages/stream/src/main/transformer.mts
+++ b/packages/stream/src/main/transformer.mts
@@ -190,10 +190,10 @@ export namespace Transformer {
   } = <T, TF>(
     pred: (value: T, index: number, halt: () => void) => boolean,
     options: { negate?: boolean | undefined } = {}
-  ): Transformer<never> => {
+  ): any => {
     const { negate = false } = options;
 
-    return flatMap((value, index, halt) =>
+    return flatMap<T, T>((value, index, halt) =>
       pred(value, index, halt) !== negate ? Stream.of(value) : Stream.empty()
     );
   };

--- a/packages/stream/test-d/async-stream.test-d.mts
+++ b/packages/stream/test-d/async-stream.test-d.mts
@@ -191,6 +191,8 @@ expectError(AsyncStream.zipAllWith());
 //   AsyncStream.zipAllWith(true, (a, b) => [a, true, b], AsyncStream.empty<number>(), AsyncStream.of('a'))
 // );
 
+// AsyncStream methods
+
 // .assumeNonEmpty()
 expectType<AsyncStream.NonEmpty<number>>(
   AsyncStream.empty<number>().assumeNonEmpty()
@@ -627,6 +629,7 @@ expectType<boolean>(
   await AsyncStream.empty<number>().reduce(AsyncReducer.isEmpty)
 );
 expectType<boolean>(await AsyncStream.of(1).reduce(AsyncReducer.isEmpty));
+expectError(AsyncStream.empty<number | boolean>().reduce([Reducer.sum]));
 
 // .reduce(..) shape
 expectType<[boolean, number, string]>(
@@ -706,3 +709,25 @@ expectType<ArrayNonEmpty<number>>(await AsyncStream.of(1).toArray());
 // .equals()
 expectType<boolean>(await AsyncStream.empty<number>().equals([1, 2]));
 expectType<boolean>(await AsyncStream.of(1, 2).equals([1, 2]));
+
+// .withOnly(...)
+expectType<AsyncStream<undefined>>(
+  AsyncStream.empty<number | undefined>().withOnly([undefined])
+);
+expectType<AsyncStream<1>>(
+  AsyncStream.empty<number | undefined>().withOnly([1])
+);
+expectType<AsyncStream<1 | 2>>(
+  AsyncStream.empty<number | undefined>().withOnly([1, 2])
+);
+
+// .without(...)
+expectType<AsyncStream<number>>(
+  AsyncStream.empty<number | undefined>().without([undefined])
+);
+expectType<AsyncStream<number | undefined>>(
+  AsyncStream.empty<number | undefined>().without([1])
+);
+expectType<AsyncStream<1 | 3>>(
+  AsyncStream.empty<1 | 2 | 3 | undefined>().without([undefined, 2])
+);

--- a/packages/stream/test/async-reducer.test.mts
+++ b/packages/stream/test/async-reducer.test.mts
@@ -690,7 +690,7 @@ describe('AsyncReducer', () => {
     {
       const red = AsyncReducer.from(Reducer.toArray<number>())
         .takeInput(2)
-        .chain(Reducer.toArray<number>().takeInput(2));
+        .chain([Reducer.toArray<number>().takeInput(2)]);
 
       expect(await AsyncStream.of(1, 2, 3, 4, 5).reduce(red)).toEqual([3, 4]);
     }
@@ -698,9 +698,9 @@ describe('AsyncReducer', () => {
     {
       const red = AsyncReducer.from(Reducer.sum)
         .takeInput(2)
-        .chain((v) =>
-          AsyncReducer.from(Reducer.product).mapOutput((o) => o + v)
-        );
+        .chain([
+          (v) => AsyncReducer.from(Reducer.product).mapOutput((o) => o + v),
+        ]);
 
       expect(await AsyncStream.of(1, 2, 3, 4).reduce(red)).toEqual(15);
     }

--- a/packages/stream/test/async-reducer.test.mts
+++ b/packages/stream/test/async-reducer.test.mts
@@ -667,19 +667,23 @@ describe('AsyncReducer', () => {
   });
 
   it('pipe', async () => {
-    const red = AsyncReducer.from(Reducer.sum).pipe(
+    const red = AsyncReducer.pipe(
+      Reducer.sum,
       Reducer.join<number>({ sep: ', ' })
     );
+
     expect(await AsyncStream.empty<number>().reduce(red)).toEqual('');
     expect(await AsyncStream.of(1).reduce(red)).toEqual('1');
-    // expect(await AsyncStream.of(1, 2, 3).reduce(red)).toEqual('1, 3, 6');
+    expect(await AsyncStream.of(1, 2, 3).reduce(red)).toEqual('1, 3, 6');
   });
 
   it('pipe 2', async () => {
-    const red = AsyncReducer.from(Reducer.sum).pipe(
+    const red = AsyncReducer.pipe(
+      Reducer.sum,
       AsyncReducer.from(Reducer.product),
       AsyncReducer.from(Reducer.join({ sep: ', ' }))
     );
+
     expect(await AsyncStream.empty<number>().reduce(red)).toEqual('');
     expect(await AsyncStream.of(1).reduce(red)).toEqual('1');
     expect(await AsyncStream.of(1, 2, 3).reduce(red)).toEqual('1, 3, 18');

--- a/packages/stream/test/async-stream.test.mts
+++ b/packages/stream/test/async-stream.test.mts
@@ -802,6 +802,22 @@ describe('AsyncStream methods', () => {
       ).toEqual([0, 1, 2, 3, 4, 5]);
     }
   });
+  it('withOnly', async () => {
+    const s3 = AsyncStream.of(1, 2, 3);
+
+    expect(s3.withOnly([])).toBe(s3);
+    expect(await s3.withOnly([1, 2, 3]).toArray()).toEqual([1, 2, 3]);
+    expect(await s3.withOnly([2]).toArray()).toEqual([2]);
+    expect(await s3.withOnly([4]).toArray()).toEqual([]);
+  });
+  it('without', async () => {
+    const s3 = AsyncStream.of(1, 2, 3);
+
+    expect(s3.without([])).toBe(s3);
+    expect(await s3.without([1, 2, 3]).toArray()).toEqual([]);
+    expect(await s3.without([2]).toArray()).toEqual([1, 3]);
+    expect(await s3.without([4]).toArray()).toEqual([1, 2, 3]);
+  });
   it('collect close', async () => {
     await testResForEach(createResourceStream([1, 2, 3]).collect((v) => true));
     await testResForEach(

--- a/packages/stream/test/reducer.test.mts
+++ b/packages/stream/test/reducer.test.mts
@@ -550,7 +550,7 @@ describe('Reducer', () => {
     {
       const red = Reducer.toArray<number>()
         .takeInput(2)
-        .chain(Reducer.toArray<number>().takeInput(2));
+        .chain([Reducer.toArray<number>().takeInput(2)]);
 
       expect(Stream.of(1, 2, 3, 4, 5).reduce(red)).toEqual([3, 4]);
     }
@@ -558,9 +558,18 @@ describe('Reducer', () => {
     {
       const red = Reducer.sum
         .takeInput(2)
-        .chain((v) => Reducer.product.mapOutput((o) => o + v));
+        .chain([(v) => Reducer.product.mapOutput((o) => o + v)]);
 
       expect(Stream.of(1, 2, 3, 4).reduce(red)).toEqual(15);
+    }
+
+    {
+      const red = Reducer.toArray<number>()
+        .takeInput(2)
+        .chain([Reducer.isEmpty]);
+
+      expect(Stream.of(1, 2, 3, 4).reduce(red)).toEqual(false);
+      expect(Stream.of(1, 2).reduce(red)).toEqual(true);
     }
   });
 });

--- a/packages/stream/test/stream.test.mts
+++ b/packages/stream/test/stream.test.mts
@@ -1,5 +1,6 @@
 import { Arr } from '@rimbu/base';
 import { Eq } from '@rimbu/common';
+import { List } from '@rimbu/list';
 
 import { Stream, Reducer } from '../src/main/index.mjs';
 
@@ -37,6 +38,7 @@ const streamRange17 = Stream.applyFilter(
   streamRange1.map((v) => [v]),
   { pred: () => true }
 ).map(([v]) => v);
+const streamRange18 = List.from(streamRange1).stream();
 
 const sources = [
   streamRange1,
@@ -56,6 +58,7 @@ const sources = [
   streamRange15,
   streamRange16,
   streamRange17,
+  streamRange18,
 ];
 
 const artificialEmpty = Stream.range({ amount: 3 }).filter(() => false);

--- a/packages/stream/test/stream.test.mts
+++ b/packages/stream/test/stream.test.mts
@@ -650,6 +650,24 @@ describe('Stream methods', () => {
     });
   });
 
+  it('withOnly', () => {
+    const s3 = Stream.of(1, 2, 3);
+
+    expect(s3.withOnly([])).toBe(s3);
+    expect(s3.withOnly([1, 2, 3]).toArray()).toEqual([1, 2, 3]);
+    expect(s3.withOnly([2]).toArray()).toEqual([2]);
+    expect(s3.withOnly([4]).toArray()).toEqual([]);
+  });
+
+  it('without', () => {
+    const s3 = Stream.of(1, 2, 3);
+
+    expect(s3.without([])).toBe(s3);
+    expect(s3.without([1, 2, 3]).toArray()).toEqual([]);
+    expect(s3.without([2]).toArray()).toEqual([1, 3]);
+    expect(s3.without([4]).toArray()).toEqual([1, 2, 3]);
+  });
+
   it('collect', () => {
     expect(Stream.empty<number>().collect((v) => v + 1)).toBe(Stream.empty());
     expect(

--- a/packages/table/src/custom/implementation/base.mts
+++ b/packages/table/src/custom/implementation/base.mts
@@ -968,7 +968,7 @@ export class TableContext<
 
   readonly reducer = <R extends UR, C extends UC, V>(
     source?: StreamSource<readonly [R, C, V]>
-  ): Reducer<[R, C, V], WithRow<Tp, R, C, V>['normal']> => {
+  ): Reducer<readonly [R, C, V], WithRow<Tp, R, C, V>['normal']> => {
     return Reducer.create(
       () =>
         undefined === source

--- a/packages/table/src/custom/interface/base.mts
+++ b/packages/table/src/custom/interface/base.mts
@@ -726,7 +726,7 @@ export namespace TableBase {
      */
     reducer<R extends UR, C extends UC, V>(
       source?: StreamSource<readonly [R, C, V]>
-    ): Reducer<[R, C, V], WithRow<Tp, R, C, V>['normal']>;
+    ): Reducer<readonly [R, C, V], WithRow<Tp, R, C, V>['normal']>;
   }
 
   export interface Context<UR, UC, Tp extends TableBase.Types = TableBase.Types>


### PR DESCRIPTION
* Makes `(Async)Reducer` invariant regarding its input type. This prevents being able to do this: `Stream.of<number | string>(1, 'a').reduce(Reducer.sum)`
* Adds the `withOnly` and `withOut` methods to `AsyncStream`, which are able to limit the values included in a stream.
* Fixes types for methods accepting (async) reducers, like `window` and `groupBy` so that they accept a wider range of Reducers.

### All Submissions:

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint and formatted your code locally prior to submission?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
