### PR TITLE
Feature/fix tojsobject

### DIFF
--- a/deno_dist/stream/main/reducer.ts
+++ b/deno_dist/stream/main/reducer.ts
@@ -1716,7 +1716,7 @@ export namespace Reducer {
    * ```
    */
   export function toJSObject<K extends string | number | symbol, V>(): Reducer<
-    [K, V],
+    readonly [K, V],
     Record<K, V>
   > {
     return create(

--- a/packages/stream/src/main/reducer.mts
+++ b/packages/stream/src/main/reducer.mts
@@ -1716,7 +1716,7 @@ export namespace Reducer {
    * ```
    */
   export function toJSObject<K extends string | number | symbol, V>(): Reducer<
-    [K, V],
+    readonly [K, V],
     Record<K, V>
   > {
     return create(


### PR DESCRIPTION
Ensures that the `Reducer.toJSObject` can receive readonly tuples.