### PR TITLE
fix(sorted): expose the `Comp` instance used for a SortedSet through the context

### DIFF
--- a/deno_dist/actor/CHANGELOG.md
+++ b/deno_dist/actor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.15.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/actor@0.15.1...@rimbu/actor@0.15.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/actor
+
 ## [0.15.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/actor@0.15.0...@rimbu/actor@0.15.1) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/actor

--- a/deno_dist/base/CHANGELOG.md
+++ b/deno_dist/base/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/base@2.0.1...@rimbu/base@2.0.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/base
+
 ## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/base@2.0.0...@rimbu/base@2.0.1) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/base

--- a/deno_dist/bimap/CHANGELOG.md
+++ b/deno_dist/bimap/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimap@2.0.3...@rimbu/bimap@2.0.4) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/bimap
+
 ## [2.0.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimap@2.0.2...@rimbu/bimap@2.0.3) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/bimultimap/CHANGELOG.md
+++ b/deno_dist/bimultimap/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimultimap@2.1.1...@rimbu/bimultimap@2.1.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/bimultimap
+
 ## [2.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/bimultimap@2.1.0...@rimbu/bimultimap@2.1.1) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/channel/CHANGELOG.md
+++ b/deno_dist/channel/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/channel@0.3.1...@rimbu/channel@0.3.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/channel
+
 ## [0.3.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/channel@0.3.0...@rimbu/channel@0.3.1) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/channel

--- a/deno_dist/collection-types/CHANGELOG.md
+++ b/deno_dist/collection-types/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/collection-types@2.1.2...@rimbu/collection-types@2.1.3) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/collection-types
+
 ## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/collection-types@2.1.1...@rimbu/collection-types@2.1.2) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/common/CHANGELOG.md
+++ b/deno_dist/common/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/common@2.0.1...@rimbu/common@2.0.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/common
+
 ## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/common@2.0.0...@rimbu/common@2.0.1) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/common

--- a/deno_dist/core/CHANGELOG.md
+++ b/deno_dist/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/rimbu-org/rimbu/compare/@rimbu/core@2.0.3...@rimbu/core@2.0.4) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/core
+
 ## [2.0.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/core@2.0.2...@rimbu/core@2.0.3) (2024-06-28)
 
 **Note:** Version bump only for package @rimbu/core

--- a/deno_dist/deep/CHANGELOG.md
+++ b/deno_dist/deep/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/deep@2.0.1...@rimbu/deep@2.0.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/deep
+
 ## [2.0.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/deep@2.0.0...@rimbu/deep@2.0.1) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/deep

--- a/deno_dist/graph/CHANGELOG.md
+++ b/deno_dist/graph/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/rimbu-org/rimbu/compare/@rimbu/graph@2.0.3...@rimbu/graph@2.0.4) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/graph
+
 ## [2.0.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/graph@2.0.2...@rimbu/graph@2.0.3) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/hashed/CHANGELOG.md
+++ b/deno_dist/hashed/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/hashed@2.1.2...@rimbu/hashed@2.1.3) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/hashed
+
 ## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/hashed@2.1.1...@rimbu/hashed@2.1.2) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/list/CHANGELOG.md
+++ b/deno_dist/list/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/list@2.1.2...@rimbu/list@2.1.3) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/list
+
 ## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/list@2.1.1...@rimbu/list@2.1.2) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/multimap/CHANGELOG.md
+++ b/deno_dist/multimap/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/multimap@2.1.1...@rimbu/multimap@2.1.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/multimap
+
 ## [2.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/multimap@2.1.0...@rimbu/multimap@2.1.1) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/multiset/CHANGELOG.md
+++ b/deno_dist/multiset/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/multiset@2.1.2...@rimbu/multiset@2.1.3) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/multiset
+
 ## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/multiset@2.1.1...@rimbu/multiset@2.1.2) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/ordered/CHANGELOG.md
+++ b/deno_dist/ordered/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/ordered@2.1.2...@rimbu/ordered@2.1.3) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/ordered
+
 ## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/ordered@2.1.1...@rimbu/ordered@2.1.2) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/proximity/CHANGELOG.md
+++ b/deno_dist/proximity/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.4](https://github.com/rimbu-org/rimbu/compare/@rimbu/proximity@2.0.3...@rimbu/proximity@2.0.4) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/proximity
+
 ## [2.0.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/proximity@2.0.2...@rimbu/proximity@2.0.3) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/reactor/CHANGELOG.md
+++ b/deno_dist/reactor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.14.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/reactor@0.14.2...@rimbu/reactor@0.14.3) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/reactor
+
 ## [0.14.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/reactor@0.14.1...@rimbu/reactor@0.14.2) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/reactor

--- a/deno_dist/sorted/CHANGELOG.md
+++ b/deno_dist/sorted/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.3](https://github.com/rimbu-org/rimbu/compare/@rimbu/sorted@2.1.2...@rimbu/sorted@2.1.3) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/sorted
+
 ## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/sorted@2.1.1...@rimbu/sorted@2.1.2) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/sorted/map/interface/index.ts
+++ b/deno_dist/sorted/map/interface/index.ts
@@ -152,6 +152,19 @@ export interface SortedMap<K, V> extends RMapBase<K, V, SortedMap.Types> {
   maxKey(): K | undefined;
   maxKey<O>(otherwise: OptLazy<O>): K | O;
   /**
+   * Returns the index of the given key in the SortedMap, or -1 if the key is not present.
+   * @param key - the key to find the index for
+   * @example
+   * ```ts
+   * const m = SortedMap.of(['b', 2], ['d', 4], ['a', 1], ['c', 3]);
+   * console.log(m.findIndex('c'))
+   * // => 2
+   * console.log(m.findIndex('q'))
+   * // => -1
+   * ```
+   */
+  findIndex(key: K): number;
+  /**
    * Returns the value associated with the maximum key of the SortedMap, or a fallback value (default: undefined)
    * if the SortedMap is empty.
    * @param otherwise - (default: undefined) the fallback value to return if the SortedMap is empty.

--- a/deno_dist/sorted/set-custom/implementation/immutable.ts
+++ b/deno_dist/sorted/set-custom/implementation/immutable.ts
@@ -66,6 +66,10 @@ export class SortedSetEmpty<T = any>
     return false;
   }
 
+  findIndex(): number {
+    return -1;
+  }
+
   add(value: T): SortedSet.NonEmpty<T> {
     return this.context.leaf([value]);
   }
@@ -143,6 +147,7 @@ export abstract class SortedSetNode<T>
     options?: { state?: TraverseState }
   ): void;
   abstract has<U>(value: RelatedTo<T, U>): boolean;
+  abstract findIndex(value: T): number;
   abstract min(): T;
   abstract max(): T;
   abstract toArray(): ArrayNonEmpty<T>;
@@ -393,6 +398,12 @@ export class SortedSetLeaf<T> extends SortedSetNode<T> {
     return this.context.findIndex(value, this.entries) >= 0;
   }
 
+  findIndex(value: T): number {
+    if (!this.context.comp.isComparable(value)) return -1;
+    const index = this.context.findIndex(value, this.entries);
+    return index < 0 ? -1 : index;
+  }
+
   getAtIndex<O>(index: number, otherwise?: OptLazy<O>): T | O {
     if (index >= this.size || -index > this.size) {
       return OptLazy(otherwise) as O;
@@ -577,6 +588,30 @@ export class SortedSetInner<T> extends SortedSetNode<T> {
     const child = this.children[childIndex];
 
     return child.has<U>(value);
+  }
+
+  findIndex(value: T): number {
+    if (!this.context.comp.isComparable(value)) return -1;
+
+    const index = this.context.findIndex(value, this.entries);
+    if (index >= 0)
+      return (
+        this.children.slice(0, index + 1).reduce((x, y) => x + y.size, 0) +
+        index
+      );
+    const childIndex = SortedIndex.next(index);
+    const child = this.children[childIndex];
+    const index$ = child.findIndex(value);
+    if (index$ >= 0) {
+      return (
+        index$ +
+        (this.children.slice(0, childIndex).reduce((x, y) => x + y.size, 0) -
+          index -
+          1)
+      );
+    }
+
+    return -1;
   }
 
   getAtIndex<O>(index: number, otherwise?: OptLazy<O>): T | O {

--- a/deno_dist/sorted/set/interface/index.ts
+++ b/deno_dist/sorted/set/interface/index.ts
@@ -1,6 +1,6 @@
 import type { RSet } from '../../../collection-types/set/index.ts';
 import type { RSetBase } from '../../../collection-types/set-custom/index.ts';
-import type { IndexRange, OptLazy, Range } from '../../../common/mod.ts';
+import type { Comp, IndexRange, OptLazy, Range } from '../../../common/mod.ts';
 import type { Stream, Streamable } from '../../../stream/mod.ts';
 
 import type { SortedSetCreators } from '../../../sorted/set-custom/index.ts';
@@ -90,6 +90,19 @@ export interface SortedSet<T> extends RSetBase<T, SortedSet.Types> {
    */
   max(): T | undefined;
   max<O>(otherwise: OptLazy<O>): T | O;
+  /**
+   * Returns the index of the given value in the SortedSet, or -1 if the value is not present.
+   * @param value - the value to find the index for
+   * @example
+   * ```ts
+   * const m = SortedSet.of('b', 'd', 'a', 'c');
+   * console.log(m.findIndex('c'))
+   * // => 2
+   * console.log(m.findIndex('q'))
+   * // => -1
+   * ```
+   */
+  findIndex(value: T): number;
   /**
    * Returns the value at the given index of the value sort order of the SortedSet, or a fallback value (default: undefined)
    * if the index is out of bounds.
@@ -219,6 +232,11 @@ export namespace SortedSet {
    */
   export interface Context<UT> extends RSetBase.Context<UT, SortedSet.Types> {
     readonly typeTag: 'SortedSet';
+
+    /**
+     * A `Comp` instance used to sort the set values.
+     */
+    readonly comp: Comp<UT>;
   }
 
   /**

--- a/deno_dist/spy/CHANGELOG.md
+++ b/deno_dist/spy/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.7.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/spy@0.7.1...@rimbu/spy@0.7.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/spy
+
 ## [0.7.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/spy@0.7.0...@rimbu/spy@0.7.1) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/spy

--- a/deno_dist/stream/CHANGELOG.md
+++ b/deno_dist/stream/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.2.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/stream@2.2.0...@rimbu/stream@2.2.1) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/stream
+
 # [2.2.0](https://github.com/rimbu-org/rimbu/compare/@rimbu/stream@2.1.0...@rimbu/stream@2.2.0) (2024-03-05)
 
 ### Bug Fixes

--- a/deno_dist/table/CHANGELOG.md
+++ b/deno_dist/table/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/table@2.1.1...@rimbu/table@2.1.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/table
+
 ## [2.1.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/table@2.1.0...@rimbu/table@2.1.1) (2024-06-28)
 
 ### Bug Fixes

--- a/deno_dist/typical/CHANGELOG.md
+++ b/deno_dist/typical/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.2](https://github.com/rimbu-org/rimbu/compare/@rimbu/typical@0.8.1...@rimbu/typical@0.8.2) (2025-05-16)
+
+**Note:** Version bump only for package @rimbu/typical
+
 ## [0.8.1](https://github.com/rimbu-org/rimbu/compare/@rimbu/typical@0.8.0...@rimbu/typical@0.8.1) (2024-03-05)
 
 **Note:** Version bump only for package @rimbu/typical

--- a/packages/sorted/src/set/interface/index.mts
+++ b/packages/sorted/src/set/interface/index.mts
@@ -1,6 +1,6 @@
 import type { RSet } from '@rimbu/collection-types/set';
 import type { RSetBase } from '@rimbu/collection-types/set-custom';
-import type { IndexRange, OptLazy, Range } from '@rimbu/common';
+import type { Comp, IndexRange, OptLazy, Range } from '@rimbu/common';
 import type { Stream, Streamable } from '@rimbu/stream';
 
 import type { SortedSetCreators } from '@rimbu/sorted/set-custom';
@@ -232,6 +232,11 @@ export namespace SortedSet {
    */
   export interface Context<UT> extends RSetBase.Context<UT, SortedSet.Types> {
     readonly typeTag: 'SortedSet';
+
+    /**
+     * A `Comp` instance used to sort the set values.
+     */
+    readonly comp: Comp<UT>;
   }
 
   /**


### PR DESCRIPTION
Fixes #263  
